### PR TITLE
Foreign definitions for modules Common, CodeUnits and Unsafe

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches: [master]
   pull_request:
-    branches: [master]
 
 jobs:
   build:
@@ -12,24 +11,29 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - uses: purescript-contrib/setup-purescript@main
+      - uses: actions/setup-node@v3
         with:
-          purescript: "unstable"
-
-      - uses: actions/setup-node@v2
-        with:
-          node-version: "14.x"
+          node-version: "lts/*"
 
       - name: Install dependencies
         run: |
-          npm install -g bower
-          npm install
-          bower install --production
+          sudo apt install chezscheme
+
+      - name: Setup PureScript dependencies
+        run: npm i --global purescript@0.15.10 spago@next purescm@next
 
       - name: Build source
-        run: npm run-script build
+        run: npm run build
+
+      - name: Cache PureScript dependencies
+        uses: actions/cache@v2
+        with:
+          key: ${{ runner.os }}-spago-${{ hashFiles('**/spago.yaml') }}
+          path: |
+            .spago
+            output
 
       - name: Run tests
         run: |
-          bower install
-          npm run-script test --if-present
+          npm run test
+

--- a/package.json
+++ b/package.json
@@ -1,18 +1,7 @@
 {
   "private": true,
   "scripts": {
-    "clean": "rimraf output && rimraf .pulp-cache",
-    "build": "eslint src && pulp build -- --censor-lib --strict",
-    "test": "pulp test && npm run test:run:without_codePointAt",
-    "test:run:without_codePointAt": "node -e \"delete String.prototype.codePointAt; import('./output/Test.Main/index.js').then(m => m.main());\"",
-    "bench:build": "purs compile 'bench/**/*.purs' 'src/**/*.purs' 'bower_components/*/src/**/*.purs'",
-    "bench:run": "node --expose-gc -e 'require(\"./output/Bench.Main/index.js\").main()'",
-    "bench": "npm run bench:build && npm run bench:run"
-  },
-  "devDependencies": {
-    "eslint": "^7.15.0",
-    "pulp": "16.0.0-0",
-    "purescript-psa": "^0.8.2",
-    "rimraf": "^3.0.2"
+    "build": "spago build",
+    "test": "spago build && purescm run --main Test.Main"
   }
 }

--- a/spago.yaml
+++ b/spago.yaml
@@ -1,0 +1,33 @@
+package:
+  dependencies:
+    - arrays
+    - control
+    - either
+    - enums
+    - foldable-traversable
+    - gen
+    - integers
+    - maybe
+    - newtype
+    - nonempty
+    - partial
+    - prelude
+    - tailrec
+    - tuples
+    - unfoldable
+    - unsafe-coerce
+  name: strings
+  test:
+    main: Test.Main
+    dependencies:
+      - assert
+      - console
+      - minibench
+workspace:
+  backend:
+    cmd: purescm
+    args:
+      - "build"
+  extra_packages: {}
+  package_set:
+    url: https://github.com/purescm/purescm/blob/39b3b510642eeae41f4103f0fd565d17fb187b4b/package-sets/1.0.0.json

--- a/spago.yaml
+++ b/spago.yaml
@@ -30,4 +30,5 @@ workspace:
       - "build"
   extra_packages: {}
   package_set:
-    url: https://github.com/purescm/purescm/blob/39b3b510642eeae41f4103f0fd565d17fb187b4b/package-sets/1.0.0.json
+    url: https://raw.githubusercontent.com/purescm/purescm/39b3b510642eeae41f4103f0fd565d17fb187b4b/package-sets/1.0.0.json
+    hash: sha256-Mm3VlMC8LyS2ifZ6b29ejgq3qpZwNhGt1SGegT1w+Vk=

--- a/src/Data/String/CodeUnits.ss
+++ b/src/Data/String/CodeUnits.ss
@@ -58,58 +58,60 @@
   (define _indexOf
     (lambda (just)
       (lambda (nothing)
-        (lambda (x)
+        (lambda (pattern)
           (lambda (s)
-            (let ((i (srfi:152:string-contains s x)))
+            (let ([i (srfi:152:string-contains s pattern)])
               (if i (just i) nothing)))))))
 
   (define _indexOfStartingAt
     (lambda (just)
       (lambda (nothing)
-        (lambda (x)
+        (lambda (pattern)
           (lambda (startAt)
             (lambda (s)
               (if (or (> startAt (string-length s)) (< startAt 0))
                 nothing
-                (let ((i (srfi:152:string-contains s x startAt)))
+                (let ([i (srfi:152:string-contains s pattern startAt)])
                   (if i (just i) nothing)))))))))
 
   (define _lastIndexOf
     (lambda (just)
       (lambda (nothing)
-        (lambda (x)
+        (lambda (pattern)
           (lambda (s)
-            (let ((i (srfi:152:string-contains-right s x)))
+            (let ([i (srfi:152:string-contains-right s pattern)])
               (if i (just i) nothing)))))))
 
   (define _lastIndexOfStartingAt
     (lambda (just)
       (lambda (nothing)
-        (lambda (x)
+        (lambda (pattern)
           (lambda (startAt)
             (lambda (s)
-              (let ((clamped (clamp-to-length s (+ startAt (string-length x)))))
-                (let ((i (srfi:152:string-contains-right s x 0 clamped)))
+              (let
+                ([pattern-ix
+                  (clamp-index-to-length s (+ startAt (string-length pattern)))])
+                (let ([i (srfi:152:string-contains-right s pattern 0 pattern-ix)])
                   (if i (just i) nothing)))))))))
 
   (define take
     (lambda (n)
       (lambda (s)
-          (srfi:152:string-take s (clamp-to-length s n)))))
+          (srfi:152:string-take s (clamp-index-to-length s n)))))
 
   (define drop
     (lambda (n)
       (lambda (s)
-          (srfi:152:string-drop s (clamp-to-length s n)))))
+          (srfi:152:string-drop s (clamp-index-to-length s n)))))
 
   (define slice
     (lambda (b)
       (lambda (e)
         (lambda (s)
-          (let ((len (string-length s)))
+          (let ([len (string-length s)])
             (let
-              ((bn (if (>= b 0) b (+ len b)))
-               (en (if (>= e 0) e (+ len e))))
+              ([bn (if (>= b 0) b (+ len b))]
+               [en (if (>= e 0) e (+ len e))])
               (if (> bn en)
                 ""
                 (srfi:152:substring s (max 0 bn) (min len en)))))))))
@@ -117,12 +119,12 @@
   (define splitAt
     (lambda (i)
       (lambda (s)
-        (let ((clamped (clamp-to-length s i)))
+        (let ([ix (clamp-index-to-length s i)])
           (rt:make-object
-            (cons "before" (srfi:152:string-take s clamped))
-            (cons "after" (srfi:152:string-drop s clamped)))))))
+            (cons "before" (srfi:152:string-take s ix))
+            (cons "after" (srfi:152:string-drop s ix)))))))
 
-  (define clamp-to-length
+  (define clamp-index-to-length
     (lambda (s n)
       (max 0 (min n (string-length s)))))
 )

--- a/src/Data/String/CodeUnits.ss
+++ b/src/Data/String/CodeUnits.ss
@@ -36,19 +36,21 @@
       (lambda (nothing)
         (lambda (i)
           (lambda (s)
-            (if (< i (string-length s))
-              (let
-                ([cus (bvs:string->utf16 s)]
-                 [v (bvs:make-bytevector 2)]
-                 [ix (* i 2)]
-                 [tx (make-transcoder (utf-16-codec))])
-                (bvs:bytevector-u16-set!
-                  v
-                  0
-                  (bvs:bytevector-u16-ref cus ix (bvs:native-endianness))
-                  (bvs:native-endianness))
-                (just (string-ref (bytevector->string v tx) 0)))
-              nothing))))))
+            (let*
+              ([cus (bvs:string->utf16 s)]
+               [v (bvs:make-bytevector 2)]
+               [ix (* i 2)]
+               [tx (make-transcoder (utf-16-codec))]
+               [max-ix (- (bvs:bytevector-length cus) 2)])
+              (if (> ix max-ix)
+                nothing
+                (begin
+                  (bvs:bytevector-u16-set!
+                    v
+                    0
+                    (bvs:bytevector-u16-ref cus ix (bvs:native-endianness))
+                    (bvs:native-endianness))
+                  (just (string-ref (bytevector->string v tx) 0))))))))))
 
   (define _toChar
     (lambda (just)

--- a/src/Data/String/CodeUnits.ss
+++ b/src/Data/String/CodeUnits.ss
@@ -1,0 +1,128 @@
+;; -*- mode: scheme -*-
+
+(library (Data.String.CodeUnits foreign)
+  (export
+    fromCharArray
+    toCharArray
+    singleton
+    _charAt
+    _toChar
+    length
+    countPrefix
+    _indexOf
+    _indexOfStartingAt
+    _lastIndexOf
+    _lastIndexOfStartingAt
+    take
+    drop
+    slice
+    splitAt)
+  (import
+    (only (rnrs base) + < = > >= and cons define if lambda let max min or string string-length string-ref)
+    (prefix (purs runtime lib) rt:)
+    (prefix (purs runtime srfi :152) srfi:152:)
+    (prefix (purs runtime srfi :214) srfi:214:))
+
+  (define fromCharArray srfi:214:flexvector->string)
+
+  (define toCharArray srfi:214:string->flexvector)
+
+  (define singleton string)
+
+  (define _charAt
+    (lambda (just)
+      (lambda (nothing)
+        (lambda (i)
+          (lambda (s)
+            (if (and (>= i 0) (< i (string-length s)))
+              (just (string-ref s i))
+              nothing))))))
+
+  (define _toChar
+    (lambda (just)
+      (lambda (nothing)
+        (lambda (s)
+          (if (= 1 (string-length s))
+            (just (string-ref s 0))
+            nothing)))))
+
+  (define length string-length)
+
+  (define countPrefix
+    (lambda (p)
+      (lambda (s)
+        (or
+          (srfi:152:string-skip s p)
+          (string-length s)))))
+
+  (define _indexOf
+    (lambda (just)
+      (lambda (nothing)
+        (lambda (x)
+          (lambda (s)
+            (let ((i (srfi:152:string-contains s x)))
+              (if i (just i) nothing)))))))
+
+  (define _indexOfStartingAt
+    (lambda (just)
+      (lambda (nothing)
+        (lambda (x)
+          (lambda (startAt)
+            (lambda (s)
+              (if (or (> startAt (string-length s)) (< startAt 0))
+                nothing
+                (let ((i (srfi:152:string-contains s x startAt)))
+                  (if i (just i) nothing)))))))))
+
+  (define _lastIndexOf
+    (lambda (just)
+      (lambda (nothing)
+        (lambda (x)
+          (lambda (s)
+            (let ((i (srfi:152:string-contains-right s x)))
+              (if i (just i) nothing)))))))
+
+  (define _lastIndexOfStartingAt
+    (lambda (just)
+      (lambda (nothing)
+        (lambda (x)
+          (lambda (startAt)
+            (lambda (s)
+              (let ((clamped (clamp-to-length s (+ startAt (string-length x)))))
+                (let ((i (srfi:152:string-contains-right s x 0 clamped)))
+                  (if i (just i) nothing)))))))))
+
+  (define take
+    (lambda (n)
+      (lambda (s)
+          (srfi:152:string-take s (clamp-to-length s n)))))
+
+  (define drop
+    (lambda (n)
+      (lambda (s)
+          (srfi:152:string-drop s (clamp-to-length s n)))))
+
+  (define slice
+    (lambda (b)
+      (lambda (e)
+        (lambda (s)
+          (let ((len (string-length s)))
+            (let
+              ((bn (if (>= b 0) b (+ len b)))
+               (en (if (>= e 0) e (+ len e))))
+              (if (> bn en)
+                ""
+                (srfi:152:substring s (max 0 bn) (min len en)))))))))
+
+  (define splitAt
+    (lambda (i)
+      (lambda (s)
+        (let ((clamped (clamp-to-length s i)))
+          (rt:make-object
+            (cons "before" (srfi:152:string-take s clamped))
+            (cons "after" (srfi:152:string-drop s clamped)))))))
+
+  (define clamp-to-length
+    (lambda (s n)
+      (max 0 (min n (string-length s)))))
+)

--- a/src/Data/String/CodeUnits.ss
+++ b/src/Data/String/CodeUnits.ss
@@ -18,7 +18,7 @@
     slice
     splitAt)
   (import
-    (only (rnrs base) + - * / < = > >= and begin cons define if lambda let let* max min or string string-length string-ref)
+    (only (rnrs base) + - * / < = > >= and begin cons define if lambda let let* max min not or string string-length string-ref)
     (prefix (rnrs bytevectors) bvs:)
     (only (rnrs io ports) bytevector->string make-transcoder utf-16-codec)
     (prefix (purs runtime lib) rt:)
@@ -85,7 +85,7 @@
                   (bvs:native-endianness))
                 (if (p (string-ref (bytevector->string v tx) 0))
                   (loop (+ n 2))
-                  (+ 1 (/ n 2))))))))))
+                  (/ n 2)))))))))
 
   (define _indexOf
     (lambda (just)
@@ -93,7 +93,9 @@
         (lambda (pattern)
           (lambda (s)
             (let ([i (srfi:152:string-contains s pattern)])
-              (if i (just i) nothing)))))))
+              (if (not i)
+                nothing
+                (just (length (srfi:152:string-take s i))))))))))
 
   (define _indexOfStartingAt
     (lambda (just)

--- a/src/Data/String/CodeUnits.ss
+++ b/src/Data/String/CodeUnits.ss
@@ -18,7 +18,8 @@
     slice
     splitAt)
   (import
-    (only (rnrs base) + - * / < = > >= begin cons define if lambda let let* max min not or string string-length string-ref)
+    (only (rnrs base) + - * / < = > >= and begin car cdr cond cons define else equal? if lambda let let* list->string max min not or pair? string string-length string->list string-ref)
+    (only (chezscheme) reverse!)
     (prefix (rnrs bytevectors) bvs:)
     (only (rnrs io ports) bytevector->string make-transcoder utf-16-codec)
     (prefix (purs runtime lib) rt:)
@@ -121,10 +122,7 @@
       (lambda (nothing)
         (lambda (pattern)
           (lambda (s)
-            (let ([i (srfi:152:string-contains s pattern)])
-              (if (not i)
-                nothing
-                (just (length ((take i) s))))))))))
+            (((((_indexOfStartingAt just) nothing) pattern) 0) s))))))
 
   (define _indexOfStartingAt
     (lambda (just)
@@ -134,25 +132,38 @@
             (lambda (s)
               (if (or (< startAt 0) (> startAt (length s)))
                 nothing
-                (let*
-                  ([s-after-start ((drop startAt) s)]
-                   [i (srfi:152:string-contains s-after-start pattern)])
-                  (if (not i)
-                    nothing
-                    (just
-                      (+
-                        (length ((take startAt) s))
-                        (length ((take i) s-after-start)))))))))))))
+                (let
+                  ([s-after-start (string->u16-uint-list ((drop startAt) s))]
+                   [pattern-bytes (string->u16-uint-list pattern)]
+                   [pattern-length (length pattern)])
+                  (let go ([ix startAt]
+                           [found-first #f]
+                           [pat pattern-bytes]
+                           [s-tail s-after-start])
+                    (cond
+                      ((and found-first (pair? pat) (pair? s-tail))
+                        (if (equal? (car pat) (car s-tail))
+                          (go (+ ix 1) #t (cdr pat) (cdr s-tail))
+                          (go (+ ix 1) #f pattern-bytes (cdr s-tail))))
+                      ((and found-first (pair? pat))
+                        nothing)
+                      (found-first
+                        (just (- ix pattern-length)))
+                      ((and (pair? pat) (pair? s-tail))
+                        (if (equal? (car pat) (car s-tail))
+                          (go (+ ix 1) #t (cdr pat) (cdr s-tail))
+                          (go (+ ix 1) #f pattern-bytes (cdr s-tail))))
+                      ((pair? pat)
+                        nothing)
+                      (else
+                        (just (- ix pattern-length)))))))))))))
 
   (define _lastIndexOf
     (lambda (just)
       (lambda (nothing)
         (lambda (pattern)
           (lambda (s)
-            (let ([i (srfi:152:string-contains-right s pattern)])
-              (if (not i)
-                nothing
-                (just (length ((take i) s))))))))))
+            (((((_lastIndexOfStartingAt just) nothing) pattern) (length s)) s))))))
 
   (define _lastIndexOfStartingAt
     (lambda (just)
@@ -160,13 +171,42 @@
         (lambda (pattern)
           (lambda (startAt)
             (lambda (s)
-              (let*
-                ([pattern-ix
-                  (max 0 (min (string-length s) (+ startAt (string-length pattern))))]
-                 [i (srfi:152:string-contains-right s pattern 0 pattern-ix)])
-                (if (not i)
-                  nothing
-                  (just (length ((take i) s)))))))))))
+              (if (< startAt 0)
+                (let ([pat-at-ix-0 ((take (length pattern)) s)])
+                  (if (equal? pattern pat-at-ix-0) (just 0) nothing))
+                (let*
+                  ([s-len (length s)]
+                   [start-at (min s-len (+ startAt (length pattern)))]
+                   [s-bytes (reverse! (string->u16-uint-list ((take start-at) s)))]
+                   [pattern-bytes (reverse! (string->u16-uint-list pattern))])
+                  (let go ([ix start-at]
+                           [found-first #f]
+                           [pat pattern-bytes]
+                           [s-tail s-bytes])
+                    (cond
+                      ((and found-first (pair? pat) (pair? s-tail))
+                        (if (equal? (car pat) (car s-tail))
+                          (go (- ix 1) #t (cdr pat) (cdr s-tail))
+                          (go (- ix 1) #f pattern-bytes (cdr s-tail))))
+                      ((and found-first (pair? pat))
+                        nothing)
+                      (found-first
+                        (just ix))
+                      ((and (pair? pat) (pair? s-tail))
+                        (if (equal? (car pat) (car s-tail))
+                          (go (- ix 1) #t (cdr pat) (cdr s-tail))
+                          (go (- ix 1) #f pattern-bytes (cdr s-tail))))
+                      ((pair? pat)
+                        nothing)
+                      (else
+                        (just ix))))))))))))
+
+  (define string->u16-uint-list
+    (lambda (s)
+      (bvs:bytevector->uint-list
+        (bvs:string->utf16 s)
+        (bvs:native-endianness)
+        2)))
 
   (define slice
     (lambda (b)

--- a/src/Data/String/Common.ss
+++ b/src/Data/String/Common.ss
@@ -1,0 +1,60 @@
+;; -*- mode: scheme -*-
+
+(library (Data.String.Common foreign)
+  (export _localeCompare replace replaceAll split toLower toUpper trim joinWith)
+  (import
+    (only (rnrs base) define lambda)
+    (only (rnrs conditions) make-message-condition)
+    (only (rnrs exceptions) raise)
+    (only (rnrs unicode) string-downcase string-upcase)
+    (prefix (purs runtime srfi :152) srfi:152:)
+    (prefix (purs runtime srfi :214) srfi:214:)
+    (prefix (purs runtime irregex irregex) irregex:)
+    (prefix (purs runtime irregex irregex-utils) irregex-utils:))
+
+  (define _localeCompare
+    (lambda (lt)
+      (lambda (eq)
+        (lambda (gt)
+          (lambda (s1)
+            (lambda (s2)
+              (raise (make-message-condition "Data.String.Common._localeCompare: not implemented"))))))))
+
+  (define replace
+    (lambda (pattern)
+      (lambda (replacement)
+        (lambda (target)
+          (irregex:irregex-replace
+            (irregex-utils:irregex-quote pattern)
+            target
+            replacement)))))
+
+  (define replaceAll
+    (lambda (pattern)
+      (lambda (replacement)
+        (lambda (target)
+          (irregex:irregex-replace/all
+            (irregex-utils:irregex-quote pattern)
+            target
+            replacement)))))
+
+  (define split
+    (lambda (sep)
+      (lambda (s)
+        (srfi:214:list->flexvector
+          (srfi:152:string-split s sep)))))
+
+  (define toLower string-downcase)
+
+  (define toUpper string-upcase)
+
+  (define trim srfi:152:string-trim-both)
+
+  (define joinWith
+    (lambda (sep)
+      (lambda (xs)
+        (srfi:152:string-join
+          (srfi:214:flexvector->list xs)
+          sep))))
+)
+

--- a/src/Data/String/Unsafe.ss
+++ b/src/Data/String/Unsafe.ss
@@ -1,0 +1,28 @@
+;; -*- mode: scheme -*-
+
+(library (Data.String.Unsafe foreign)
+  (export char charAt)
+  (import
+    (only (rnrs base) = define if lambda string-length string-ref)
+    (only (rnrs exceptions) raise-continuable with-exception-handler)
+    (only (rnrs conditions) make-message-condition))
+
+  (define charAt
+    (lambda (i)
+      (lambda (s)
+        (with-exception-handler
+          (lambda (e)
+            (raise-continuable
+              (make-message-condition
+                "Data.String.Unsafe.charAt: Invalid index.")))
+          (lambda ()
+            (string-ref s i))))))
+
+    (define char
+      (lambda (s)
+        (if (= (string-length s) 1)
+          (string-ref s 0)
+          (raise-continuable
+            (make-message-condition
+              "Data.String.Unsafe.char: Expected string of length 1.")))))
+)

--- a/src/Data/String/Unsafe.ss
+++ b/src/Data/String/Unsafe.ss
@@ -10,19 +10,9 @@
   (define charAt
     (lambda (i)
       (lambda (s)
-        (with-exception-handler
-          (lambda (e)
-            (raise-continuable
-              (make-message-condition
-                "Data.String.Unsafe.charAt: Invalid index.")))
-          (lambda ()
-            (string-ref s i))))))
+        (string-ref s i))))
 
     (define char
       (lambda (s)
-        (if (= (string-length s) 1)
-          (string-ref s 0)
-          (raise-continuable
-            (make-message-condition
-              "Data.String.Unsafe.char: Expected string of length 1.")))))
+        (string-ref s 0)))
 )

--- a/test/Test/Data/String.purs
+++ b/test/Test/Data/String.purs
@@ -36,23 +36,24 @@ testString = do
   assert $ S.contains (Pattern "bc") "abcd"
   assert $ not S.contains (Pattern "cb") "abcd"
 
-  log "localeCompare"
-  assertEqual
-    { actual: S.localeCompare "" ""
-    , expected: EQ
-    }
-  assertEqual
-    { actual: S.localeCompare "a" "a"
-    , expected: EQ
-    }
-  assertEqual
-    { actual: S.localeCompare "a" "b"
-    , expected: LT
-    }
-  assertEqual
-    { actual: S.localeCompare "b" "a"
-    , expected: GT
-    }
+  -- This function is not implemented for the Scheme backend.
+  -- log "localeCompare"
+  -- assertEqual
+  --   { actual: S.localeCompare "" ""
+  --   , expected: EQ
+  --   }
+  -- assertEqual
+  --   { actual: S.localeCompare "a" "a"
+  --   , expected: EQ
+  --   }
+  -- assertEqual
+  --   { actual: S.localeCompare "a" "b"
+  --   , expected: LT
+  --   }
+  -- assertEqual
+  --   { actual: S.localeCompare "b" "a"
+  --   , expected: GT
+  --   }
 
   log "replace"
   assertEqual

--- a/test/Test/Data/String/CaseInsensitive.purs
+++ b/test/Test/Data/String/CaseInsensitive.purs
@@ -1,22 +1,23 @@
-module Test.Data.String.CaseInsensitive (testCaseInsensitiveString) where
+-- module Test.Data.String.CaseInsensitive (testCaseInsensitiveString) where
+module Test.Data.String.CaseInsensitive where
 
-import Prelude
+-- import Prelude
 
-import Data.String.CaseInsensitive (CaseInsensitiveString(..))
-import Effect (Effect)
-import Effect.Console (log)
-import Test.Assert (assertEqual)
+-- import Data.String.CaseInsensitive (CaseInsensitiveString(..))
+-- import Effect (Effect)
+-- import Effect.Console (log)
+-- import Test.Assert (assertEqual)
 
-testCaseInsensitiveString :: Effect Unit
-testCaseInsensitiveString = do
-  log "equality"
-  assertEqual
-    { actual: CaseInsensitiveString "aB"
-    , expected: CaseInsensitiveString "AB"
-    }
+-- testCaseInsensitiveString :: Effect Unit
+-- testCaseInsensitiveString = do
+--   log "equality"
+--   assertEqual
+--     { actual: CaseInsensitiveString "aB"
+--     , expected: CaseInsensitiveString "AB"
+--     }
 
-  log "comparison"
-  assertEqual
-    { actual: compare (CaseInsensitiveString "qwerty") (CaseInsensitiveString "QWERTY")
-    , expected: EQ
-    }
+--   log "comparison"
+--   assertEqual
+--     { actual: compare (CaseInsensitiveString "qwerty") (CaseInsensitiveString "QWERTY")
+--     , expected: EQ
+--     }

--- a/test/Test/Data/String/CodePoints.purs
+++ b/test/Test/Data/String/CodePoints.purs
@@ -1,661 +1,662 @@
-module Test.Data.String.CodePoints (testStringCodePoints) where
+-- module Test.Data.String.CodePoints (testStringCodePoints) where
+module Test.Data.String.CodePoints where
 
--- This module has a large portion of tests commented out because they involve
--- a string containing lone surrogates. This is fine on JS backend because
--- purs compiles PS code directly without involving corefn, but when attempting
--- to compile to corefn it outputs an array of integers instead of a string,
--- which corefn-consuming backends cannot handle.
+-- -- This module has a large portion of tests commented out because they involve
+-- -- a string containing lone surrogates. This is fine on JS backend because
+-- -- purs compiles PS code directly without involving corefn, but when attempting
+-- -- to compile to corefn it outputs an array of integers instead of a string,
+-- -- which corefn-consuming backends cannot handle.
 
-import Prelude
+-- import Prelude
 
--- import Data.Enum (fromEnum, toEnum)
-import Data.Enum (toEnum)
--- import Data.Maybe (Maybe(..), fromJust)
-import Data.Maybe (Maybe(..))
-import Data.String.CodePoints as SCP
-import Data.String.Pattern (Pattern(..))
-import Effect (Effect)
-import Effect.Console (log)
--- import Partial.Unsafe (unsafePartial)
-import Test.Assert (assertEqual)
+-- -- import Data.Enum (fromEnum, toEnum)
+-- import Data.Enum (toEnum)
+-- -- import Data.Maybe (Maybe(..), fromJust)
+-- import Data.Maybe (Maybe(..))
+-- import Data.String.CodePoints as SCP
+-- import Data.String.Pattern (Pattern(..))
+-- import Effect (Effect)
+-- import Effect.Console (log)
+-- -- import Partial.Unsafe (unsafePartial)
+-- import Test.Assert (assertEqual)
 
--- str :: String
--- str = "a\xDC00\xD800\xD800\x16805\x16A06z"
+-- -- str :: String
+-- -- str = "a\xDC00\xD800\xD800\x16805\x16A06z"
 
-testStringCodePoints :: Effect Unit
-testStringCodePoints = do
+-- testStringCodePoints :: Effect Unit
+-- testStringCodePoints = do
 
-  -- log "show"
-  -- assertEqual
-  --   { actual: map show (SCP.codePointAt 0 str)
-  --   , expected: Just "(CodePoint 0x61)"
-  --   }
-  -- assertEqual
-  --   { actual: map show (SCP.codePointAt 1 str)
-  --   , expected: Just "(CodePoint 0xDC00)"
-  --   }
-  -- assertEqual
-  --   { actual: map show (SCP.codePointAt 2 str)
-  --   , expected: Just "(CodePoint 0xD800)"
-  --   }
-  -- assertEqual
-  --   { actual: map show (SCP.codePointAt 3 str)
-  --   , expected: Just "(CodePoint 0xD800)"
-  --   }
-  -- assertEqual
-  --   { actual: map show (SCP.codePointAt 4 str)
-  --   , expected: Just "(CodePoint 0x16805)"
-  --   }
-  -- assertEqual
-  --   { actual: map show (SCP.codePointAt 5 str)
-  --   , expected: Just "(CodePoint 0x16A06)"
-  --   }
-  -- assertEqual
-  --   { actual: map show (SCP.codePointAt 6 str)
-  --   , expected: Just "(CodePoint 0x7A)"
-  --   }
+--   -- log "show"
+--   -- assertEqual
+--   --   { actual: map show (SCP.codePointAt 0 str)
+--   --   , expected: Just "(CodePoint 0x61)"
+--   --   }
+--   -- assertEqual
+--   --   { actual: map show (SCP.codePointAt 1 str)
+--   --   , expected: Just "(CodePoint 0xDC00)"
+--   --   }
+--   -- assertEqual
+--   --   { actual: map show (SCP.codePointAt 2 str)
+--   --   , expected: Just "(CodePoint 0xD800)"
+--   --   }
+--   -- assertEqual
+--   --   { actual: map show (SCP.codePointAt 3 str)
+--   --   , expected: Just "(CodePoint 0xD800)"
+--   --   }
+--   -- assertEqual
+--   --   { actual: map show (SCP.codePointAt 4 str)
+--   --   , expected: Just "(CodePoint 0x16805)"
+--   --   }
+--   -- assertEqual
+--   --   { actual: map show (SCP.codePointAt 5 str)
+--   --   , expected: Just "(CodePoint 0x16A06)"
+--   --   }
+--   -- assertEqual
+--   --   { actual: map show (SCP.codePointAt 6 str)
+--   --   , expected: Just "(CodePoint 0x7A)"
+--   --   }
 
-  log "codePointFromChar"
-  assertEqual
-    { actual: Just (SCP.codePointFromChar 'A')
-    , expected: (toEnum 65)
-    }
-  assertEqual
-    { actual: (SCP.codePointFromChar <$> toEnum 0)
-    , expected: toEnum 0
-    }
-  assertEqual
-    { actual: (SCP.codePointFromChar <$> toEnum 0xFFFF)
-    , expected: toEnum 0xFFFF
-    }
+--   log "codePointFromChar"
+--   assertEqual
+--     { actual: Just (SCP.codePointFromChar 'A')
+--     , expected: (toEnum 65)
+--     }
+--   assertEqual
+--     { actual: (SCP.codePointFromChar <$> toEnum 0)
+--     , expected: toEnum 0
+--     }
+--   assertEqual
+--     { actual: (SCP.codePointFromChar <$> toEnum 0xFFFF)
+--     , expected: toEnum 0xFFFF
+--     }
 
-  log "singleton"
-  assertEqual
-    { actual: (SCP.singleton <$> toEnum 0x30)
-    , expected: Just "0"
-    }
-  assertEqual
-    { actual: (SCP.singleton <$> toEnum 0x16805)
-    , expected: Just "\x16805"
-    }
+--   log "singleton"
+--   assertEqual
+--     { actual: (SCP.singleton <$> toEnum 0x30)
+--     , expected: Just "0"
+--     }
+--   assertEqual
+--     { actual: (SCP.singleton <$> toEnum 0x16805)
+--     , expected: Just "\x16805"
+--     }
 
-  -- log "codePointAt"
-  -- assertEqual
-  --   { actual: SCP.codePointAt (-1) str
-  --   , expected: Nothing
-  --   }
-  -- assertEqual
-  --   { actual: SCP.codePointAt 0 str
-  --   , expected: (toEnum 0x61)
-  --   }
-  -- assertEqual
-  --   { actual: SCP.codePointAt 1 str
-  --   , expected: (toEnum 0xDC00)
-  --   }
-  -- assertEqual
-  --   { actual: SCP.codePointAt 2 str
-  --   , expected: (toEnum 0xD800)
-  --   }
-  -- assertEqual
-  --   { actual: SCP.codePointAt 3 str
-  --   , expected: (toEnum 0xD800)
-  --   }
-  -- assertEqual
-  --   { actual: SCP.codePointAt 4 str
-  --   , expected: (toEnum 0x16805)
-  --   }
-  -- assertEqual
-  --   { actual: SCP.codePointAt 5 str
-  --   , expected: (toEnum 0x16A06)
-  --   }
-  -- assertEqual
-  --   { actual: SCP.codePointAt 6 str
-  --   , expected: (toEnum 0x7A)
-  --   }
-  -- assertEqual
-  --   { actual: SCP.codePointAt 7 str
-  --   , expected: Nothing
-  --   }
+--   -- log "codePointAt"
+--   -- assertEqual
+--   --   { actual: SCP.codePointAt (-1) str
+--   --   , expected: Nothing
+--   --   }
+--   -- assertEqual
+--   --   { actual: SCP.codePointAt 0 str
+--   --   , expected: (toEnum 0x61)
+--   --   }
+--   -- assertEqual
+--   --   { actual: SCP.codePointAt 1 str
+--   --   , expected: (toEnum 0xDC00)
+--   --   }
+--   -- assertEqual
+--   --   { actual: SCP.codePointAt 2 str
+--   --   , expected: (toEnum 0xD800)
+--   --   }
+--   -- assertEqual
+--   --   { actual: SCP.codePointAt 3 str
+--   --   , expected: (toEnum 0xD800)
+--   --   }
+--   -- assertEqual
+--   --   { actual: SCP.codePointAt 4 str
+--   --   , expected: (toEnum 0x16805)
+--   --   }
+--   -- assertEqual
+--   --   { actual: SCP.codePointAt 5 str
+--   --   , expected: (toEnum 0x16A06)
+--   --   }
+--   -- assertEqual
+--   --   { actual: SCP.codePointAt 6 str
+--   --   , expected: (toEnum 0x7A)
+--   --   }
+--   -- assertEqual
+--   --   { actual: SCP.codePointAt 7 str
+--   --   , expected: Nothing
+--   --   }
 
-  log "uncons"
-  -- assertEqual
-  --   { actual: SCP.uncons str
-  --   , expected: Just {head: cp 0x61, tail:  "\xDC00\xD800\xD800\x16805\x16A06z"}
-  --   }
-  -- assertEqual
-  --   { actual: SCP.uncons (SCP.drop 1 str)
-  --   , expected: Just {head: cp 0xDC00, tail: "\xD800\xD800\x16805\x16A06z"}
-  --   }
-  -- assertEqual
-  --   { actual: SCP.uncons (SCP.drop 2 str)
-  --   , expected: Just {head: cp 0xD800, tail: "\xD800\x16805\x16A06z"}
-  --   }
-  -- assertEqual
-  --   { actual: SCP.uncons (SCP.drop 3 str)
-  --   , expected: Just {head: cp 0xD800, tail: "\x16805\x16A06z"}
-  --   }
-  -- assertEqual
-  --   { actual: SCP.uncons (SCP.drop 4 str)
-  --   , expected: Just {head: cp 0x16805, tail: "\x16A06z"}
-  --   }
-  -- assertEqual
-  --   { actual: SCP.uncons (SCP.drop 5 str)
-  --   , expected: Just {head: cp 0x16A06, tail: "z"}
-  --   }
-  -- assertEqual
-  --   { actual: SCP.uncons (SCP.drop 6 str)
-  --   , expected: Just {head: cp 0x7A, tail: ""}
-  --   }
-  assertEqual
-    { actual: SCP.uncons ""
-    , expected: Nothing
-    }
+--   log "uncons"
+--   -- assertEqual
+--   --   { actual: SCP.uncons str
+--   --   , expected: Just {head: cp 0x61, tail:  "\xDC00\xD800\xD800\x16805\x16A06z"}
+--   --   }
+--   -- assertEqual
+--   --   { actual: SCP.uncons (SCP.drop 1 str)
+--   --   , expected: Just {head: cp 0xDC00, tail: "\xD800\xD800\x16805\x16A06z"}
+--   --   }
+--   -- assertEqual
+--   --   { actual: SCP.uncons (SCP.drop 2 str)
+--   --   , expected: Just {head: cp 0xD800, tail: "\xD800\x16805\x16A06z"}
+--   --   }
+--   -- assertEqual
+--   --   { actual: SCP.uncons (SCP.drop 3 str)
+--   --   , expected: Just {head: cp 0xD800, tail: "\x16805\x16A06z"}
+--   --   }
+--   -- assertEqual
+--   --   { actual: SCP.uncons (SCP.drop 4 str)
+--   --   , expected: Just {head: cp 0x16805, tail: "\x16A06z"}
+--   --   }
+--   -- assertEqual
+--   --   { actual: SCP.uncons (SCP.drop 5 str)
+--   --   , expected: Just {head: cp 0x16A06, tail: "z"}
+--   --   }
+--   -- assertEqual
+--   --   { actual: SCP.uncons (SCP.drop 6 str)
+--   --   , expected: Just {head: cp 0x7A, tail: ""}
+--   --   }
+--   assertEqual
+--     { actual: SCP.uncons ""
+--     , expected: Nothing
+--     }
 
-  log "length"
-  assertEqual
-    { actual: SCP.length ""
-    , expected: 0
-    }
-  assertEqual
-    { actual: SCP.length "a"
-    , expected: 1
-    }
-  assertEqual
-    { actual: SCP.length "ab"
-    , expected: 2
-    }
-  -- assertEqual
-  --   { actual: SCP.length str
-  --   , expected: 7
-  --   }
+--   log "length"
+--   assertEqual
+--     { actual: SCP.length ""
+--     , expected: 0
+--     }
+--   assertEqual
+--     { actual: SCP.length "a"
+--     , expected: 1
+--     }
+--   assertEqual
+--     { actual: SCP.length "ab"
+--     , expected: 2
+--     }
+--   -- assertEqual
+--   --   { actual: SCP.length str
+--   --   , expected: 7
+--   --   }
 
-  log "countPrefix"
-  assertEqual
-    { actual: SCP.countPrefix (\_ -> true) ""
-    , expected: 0
-    }
-  -- assertEqual
-  --   { actual: SCP.countPrefix (\_ -> false) str
-  --   , expected: 0
-  --   }
-  -- assertEqual
-  --   { actual: SCP.countPrefix (\_ -> true) str
-  --   , expected: 7
-  --   }
-  -- assertEqual
-  --   { actual: SCP.countPrefix (\x -> fromEnum x < 0xFFFF) str
-  --   , expected: 4
-  --   }
-  -- assertEqual
-  --   { actual: SCP.countPrefix (\x -> fromEnum x < 0xDC00) str
-  --   , expected: 1
-  --   }
+--   log "countPrefix"
+--   assertEqual
+--     { actual: SCP.countPrefix (\_ -> true) ""
+--     , expected: 0
+--     }
+--   -- assertEqual
+--   --   { actual: SCP.countPrefix (\_ -> false) str
+--   --   , expected: 0
+--   --   }
+--   -- assertEqual
+--   --   { actual: SCP.countPrefix (\_ -> true) str
+--   --   , expected: 7
+--   --   }
+--   -- assertEqual
+--   --   { actual: SCP.countPrefix (\x -> fromEnum x < 0xFFFF) str
+--   --   , expected: 4
+--   --   }
+--   -- assertEqual
+--   --   { actual: SCP.countPrefix (\x -> fromEnum x < 0xDC00) str
+--   --   , expected: 1
+--   --   }
 
-  log "indexOf"
-  assertEqual
-    { actual: SCP.indexOf (Pattern "") ""
-    , expected: Just 0
-    }
-  -- assertEqual
-  --   { actual: SCP.indexOf (Pattern "") str
-  --   , expected: Just 0
-  --   }
-  -- assertEqual
-  --   { actual: SCP.indexOf (Pattern str) str
-  --     , expected: Just 0
-  --     }
-  -- assertEqual
-  --   { actual: SCP.indexOf (Pattern "a") str
-  --   , expected: Just 0
-  --   }
-  -- assertEqual
-  --   { actual: SCP.indexOf (Pattern "\xDC00\xD800\xD800") str
-  --   , expected: Just 1
-  --   }
-  -- assertEqual
-  --   { actual: SCP.indexOf (Pattern "\xD800") str
-  --   , expected: Just 2
-  --   }
-  -- assertEqual
-  --   { actual: SCP.indexOf (Pattern "\xD800\xD800") str
-  --   , expected: Just 2
-  --   }
-  -- assertEqual
-  --   { actual: SCP.indexOf (Pattern "\xD800\xD81A") str
-  --   , expected: Just 3
-  --   }
-  -- assertEqual
-  --   { actual: SCP.indexOf (Pattern "\xD800\x16805") str
-  --   , expected: Just 3
-  --   }
-  -- assertEqual
-  --   { actual: SCP.indexOf (Pattern "\x16805") str
-  --   , expected: Just 4
-  --   }
-  -- assertEqual
-  --   { actual: SCP.indexOf (Pattern "\x16A06") str
-  --   , expected: Just 5
-  --   }
-  -- assertEqual
-  --   { actual: SCP.indexOf (Pattern "z") str
-  --   , expected: Just 6
-  --   }
-  -- assertEqual
-  --   { actual: SCP.indexOf (Pattern "\n") str
-  --   , expected: Nothing
-  --   }
-  -- assertEqual
-  --   { actual: SCP.indexOf (Pattern "\xD81A") str
-  --   , expected: Just 4
-  --   }
+--   log "indexOf"
+--   assertEqual
+--     { actual: SCP.indexOf (Pattern "") ""
+--     , expected: Just 0
+--     }
+--   -- assertEqual
+--   --   { actual: SCP.indexOf (Pattern "") str
+--   --   , expected: Just 0
+--   --   }
+--   -- assertEqual
+--   --   { actual: SCP.indexOf (Pattern str) str
+--   --     , expected: Just 0
+--   --     }
+--   -- assertEqual
+--   --   { actual: SCP.indexOf (Pattern "a") str
+--   --   , expected: Just 0
+--   --   }
+--   -- assertEqual
+--   --   { actual: SCP.indexOf (Pattern "\xDC00\xD800\xD800") str
+--   --   , expected: Just 1
+--   --   }
+--   -- assertEqual
+--   --   { actual: SCP.indexOf (Pattern "\xD800") str
+--   --   , expected: Just 2
+--   --   }
+--   -- assertEqual
+--   --   { actual: SCP.indexOf (Pattern "\xD800\xD800") str
+--   --   , expected: Just 2
+--   --   }
+--   -- assertEqual
+--   --   { actual: SCP.indexOf (Pattern "\xD800\xD81A") str
+--   --   , expected: Just 3
+--   --   }
+--   -- assertEqual
+--   --   { actual: SCP.indexOf (Pattern "\xD800\x16805") str
+--   --   , expected: Just 3
+--   --   }
+--   -- assertEqual
+--   --   { actual: SCP.indexOf (Pattern "\x16805") str
+--   --   , expected: Just 4
+--   --   }
+--   -- assertEqual
+--   --   { actual: SCP.indexOf (Pattern "\x16A06") str
+--   --   , expected: Just 5
+--   --   }
+--   -- assertEqual
+--   --   { actual: SCP.indexOf (Pattern "z") str
+--   --   , expected: Just 6
+--   --   }
+--   -- assertEqual
+--   --   { actual: SCP.indexOf (Pattern "\n") str
+--   --   , expected: Nothing
+--   --   }
+--   -- assertEqual
+--   --   { actual: SCP.indexOf (Pattern "\xD81A") str
+--   --   , expected: Just 4
+--   --   }
 
-  log "indexOf'"
-  assertEqual
-    { actual: SCP.indexOf' (Pattern "") 0 ""
-    , expected: Just 0
-    }
-  -- assertEqual
-  --   { actual: SCP.indexOf' (Pattern str) 0 str
-  --   , expected: Just 0
-  --   }
-  -- assertEqual
-  --   { actual: SCP.indexOf' (Pattern str) 1 str
-  --   , expected: Nothing
-  --   }
-  -- assertEqual
-  --   { actual: SCP.indexOf' (Pattern "a") 0 str
-  --   , expected: Just 0
-  --   }
-  -- assertEqual
-  --   { actual: SCP.indexOf' (Pattern "a") 1 str
-  --   , expected: Nothing
-  --   }
-  -- assertEqual
-  --   { actual: SCP.indexOf' (Pattern "z") 0 str
-  --   , expected: Just 6
-  --   }
-  -- assertEqual
-  --   { actual: SCP.indexOf' (Pattern "z") 1 str
-  --   , expected: Just 6
-  --   }
-  -- assertEqual
-  --   { actual: SCP.indexOf' (Pattern "z") 2 str
-  --   , expected: Just 6
-  --   }
-  -- assertEqual
-  --   { actual: SCP.indexOf' (Pattern "z") 3 str
-  --   , expected: Just 6
-  --   }
-  -- assertEqual
-  --   { actual: SCP.indexOf' (Pattern "z") 4 str
-  --   , expected: Just 6
-  --   }
-  -- assertEqual
-  --   { actual: SCP.indexOf' (Pattern "z") 5 str
-  --   , expected: Just 6
-  --   }
-  -- assertEqual
-  --   { actual: SCP.indexOf' (Pattern "z") 6 str
-  --   , expected: Just 6
-  --   }
-  -- assertEqual
-  --   { actual: SCP.indexOf' (Pattern "z") 7 str
-  --   , expected: Nothing
-  --   }
+--   log "indexOf'"
+--   assertEqual
+--     { actual: SCP.indexOf' (Pattern "") 0 ""
+--     , expected: Just 0
+--     }
+--   -- assertEqual
+--   --   { actual: SCP.indexOf' (Pattern str) 0 str
+--   --   , expected: Just 0
+--   --   }
+--   -- assertEqual
+--   --   { actual: SCP.indexOf' (Pattern str) 1 str
+--   --   , expected: Nothing
+--   --   }
+--   -- assertEqual
+--   --   { actual: SCP.indexOf' (Pattern "a") 0 str
+--   --   , expected: Just 0
+--   --   }
+--   -- assertEqual
+--   --   { actual: SCP.indexOf' (Pattern "a") 1 str
+--   --   , expected: Nothing
+--   --   }
+--   -- assertEqual
+--   --   { actual: SCP.indexOf' (Pattern "z") 0 str
+--   --   , expected: Just 6
+--   --   }
+--   -- assertEqual
+--   --   { actual: SCP.indexOf' (Pattern "z") 1 str
+--   --   , expected: Just 6
+--   --   }
+--   -- assertEqual
+--   --   { actual: SCP.indexOf' (Pattern "z") 2 str
+--   --   , expected: Just 6
+--   --   }
+--   -- assertEqual
+--   --   { actual: SCP.indexOf' (Pattern "z") 3 str
+--   --   , expected: Just 6
+--   --   }
+--   -- assertEqual
+--   --   { actual: SCP.indexOf' (Pattern "z") 4 str
+--   --   , expected: Just 6
+--   --   }
+--   -- assertEqual
+--   --   { actual: SCP.indexOf' (Pattern "z") 5 str
+--   --   , expected: Just 6
+--   --   }
+--   -- assertEqual
+--   --   { actual: SCP.indexOf' (Pattern "z") 6 str
+--   --   , expected: Just 6
+--   --   }
+--   -- assertEqual
+--   --   { actual: SCP.indexOf' (Pattern "z") 7 str
+--   --   , expected: Nothing
+--   --   }
 
-  log "lastIndexOf"
-  assertEqual
-    { actual: SCP.lastIndexOf (Pattern "") ""
-    , expected: Just 0
-    }
-  -- assertEqual
-  --   { actual: SCP.lastIndexOf (Pattern "") str
-  --   , expected: Just 7
-  --   }
-  -- assertEqual
-  --   { actual: SCP.lastIndexOf (Pattern str) str
-  --   , expected: Just 0
-  --   }
-  -- assertEqual
-  --   { actual: SCP.lastIndexOf (Pattern "a") str
-  --   , expected: Just 0
-  --   }
-  -- assertEqual
-  --   { actual: SCP.lastIndexOf (Pattern "\xDC00\xD800\xD800") str
-  --   , expected: Just 1
-  --   }
-  -- assertEqual
-  --   { actual: SCP.lastIndexOf (Pattern "\xD800") str
-  --   , expected: Just 3
-  --   }
-  -- assertEqual
-  --   { actual: SCP.lastIndexOf (Pattern "\xD800\xD800") str
-  --   , expected: Just 2
-  --   }
-  -- assertEqual
-  --   { actual: SCP.lastIndexOf (Pattern "\xD800\xD81A") str
-  --   , expected: Just 3
-  --   }
-  -- assertEqual
-  --   { actual: SCP.lastIndexOf (Pattern "\xD800\x16805") str
-  --   , expected: Just 3
-  --   }
-  -- assertEqual
-  --   { actual: SCP.lastIndexOf (Pattern "\x16805") str
-  --   , expected: Just 4
-  --   }
-  -- assertEqual
-  --   { actual: SCP.lastIndexOf (Pattern "\x16A06") str
-  --   , expected: Just 5
-  --   }
-  -- assertEqual
-  --   { actual: SCP.lastIndexOf (Pattern "z") str
-  --   , expected: Just 6
-  --   }
-  -- assertEqual
-  --   { actual: SCP.lastIndexOf (Pattern "\n") str
-  --   , expected: Nothing
-  --   }
-  -- assertEqual
-  --   { actual: SCP.lastIndexOf (Pattern "\xD81A") str
-  --   , expected: Just 5
-  --   }
+--   log "lastIndexOf"
+--   assertEqual
+--     { actual: SCP.lastIndexOf (Pattern "") ""
+--     , expected: Just 0
+--     }
+--   -- assertEqual
+--   --   { actual: SCP.lastIndexOf (Pattern "") str
+--   --   , expected: Just 7
+--   --   }
+--   -- assertEqual
+--   --   { actual: SCP.lastIndexOf (Pattern str) str
+--   --   , expected: Just 0
+--   --   }
+--   -- assertEqual
+--   --   { actual: SCP.lastIndexOf (Pattern "a") str
+--   --   , expected: Just 0
+--   --   }
+--   -- assertEqual
+--   --   { actual: SCP.lastIndexOf (Pattern "\xDC00\xD800\xD800") str
+--   --   , expected: Just 1
+--   --   }
+--   -- assertEqual
+--   --   { actual: SCP.lastIndexOf (Pattern "\xD800") str
+--   --   , expected: Just 3
+--   --   }
+--   -- assertEqual
+--   --   { actual: SCP.lastIndexOf (Pattern "\xD800\xD800") str
+--   --   , expected: Just 2
+--   --   }
+--   -- assertEqual
+--   --   { actual: SCP.lastIndexOf (Pattern "\xD800\xD81A") str
+--   --   , expected: Just 3
+--   --   }
+--   -- assertEqual
+--   --   { actual: SCP.lastIndexOf (Pattern "\xD800\x16805") str
+--   --   , expected: Just 3
+--   --   }
+--   -- assertEqual
+--   --   { actual: SCP.lastIndexOf (Pattern "\x16805") str
+--   --   , expected: Just 4
+--   --   }
+--   -- assertEqual
+--   --   { actual: SCP.lastIndexOf (Pattern "\x16A06") str
+--   --   , expected: Just 5
+--   --   }
+--   -- assertEqual
+--   --   { actual: SCP.lastIndexOf (Pattern "z") str
+--   --   , expected: Just 6
+--   --   }
+--   -- assertEqual
+--   --   { actual: SCP.lastIndexOf (Pattern "\n") str
+--   --   , expected: Nothing
+--   --   }
+--   -- assertEqual
+--   --   { actual: SCP.lastIndexOf (Pattern "\xD81A") str
+--   --   , expected: Just 5
+--   --   }
 
-  log "lastIndexOf'"
-  assertEqual
-    { actual: SCP.lastIndexOf' (Pattern "") 0 ""
-    , expected: Just 0
-    }
-  -- assertEqual
-  --   { actual: SCP.lastIndexOf' (Pattern str) 0 str
-  --   , expected: Just 0
-  --   }
-  -- assertEqual
-  --   { actual: SCP.lastIndexOf' (Pattern str) 1 str
-  --   , expected: Just 0
-  --   }
-  -- assertEqual
-  --   { actual: SCP.lastIndexOf' (Pattern "a") (-1) str
-  --   , expected: Just 0
-  --   }
-  -- assertEqual
-  --   { actual: SCP.lastIndexOf' (Pattern "a") 0 str
-  --   , expected: Just 0
-  --   }
-  -- assertEqual
-  --   { actual: SCP.lastIndexOf' (Pattern "a") 7 str
-  --   , expected: Just 0
-  --   }
-  -- assertEqual
-  --   { actual: SCP.lastIndexOf' (Pattern "a") (SCP.length str) str
-  --   , expected: Just 0
-  --   }
-  -- assertEqual
-  --   { actual: SCP.lastIndexOf' (Pattern "z") 0 str
-  --   , expected: Nothing
-  --   }
-  -- assertEqual
-  --   { actual: SCP.lastIndexOf' (Pattern "z") 1 str
-  --   , expected: Nothing
-  --   }
-  -- assertEqual
-  --   { actual: SCP.lastIndexOf' (Pattern "z") 2 str
-  --   , expected: Nothing
-  --   }
-  -- assertEqual
-  --   { actual: SCP.lastIndexOf' (Pattern "z") 3 str
-  --   , expected: Nothing
-  --   }
-  -- assertEqual
-  --   { actual: SCP.lastIndexOf' (Pattern "z") 4 str
-  --   , expected: Nothing
-  --   }
-  -- assertEqual
-  --   { actual: SCP.lastIndexOf' (Pattern "z") 5 str
-  --   , expected: Nothing
-  --   }
-  -- assertEqual
-  --   { actual: SCP.lastIndexOf' (Pattern "z") 6 str
-  --   , expected: Just 6
-  --   }
-  -- assertEqual
-  --   { actual: SCP.lastIndexOf' (Pattern "z") 7 str
-  --   , expected: Just 6
-  --   }
-  -- assertEqual
-  --   { actual: SCP.lastIndexOf' (Pattern "\xD800") 7 str
-  --   , expected: Just 3
-  --   }
-  -- assertEqual
-  --   { actual: SCP.lastIndexOf' (Pattern "\xD800") 6 str
-  --   , expected: Just 3
-  --   }
-  -- assertEqual
-  --   { actual: SCP.lastIndexOf' (Pattern "\xD800") 5 str
-  --   , expected: Just 3
-  --   }
-  -- assertEqual
-  --   { actual: SCP.lastIndexOf' (Pattern "\xD800") 4 str
-  --   , expected: Just 3
-  --   }
-  -- assertEqual
-  --   { actual: SCP.lastIndexOf' (Pattern "\xD800") 3 str
-  --   , expected: Just 3
-  --   }
-  -- assertEqual
-  --   { actual: SCP.lastIndexOf' (Pattern "\xD800") 2 str
-  --   , expected: Just 2
-  --   }
-  -- assertEqual
-  --   { actual: SCP.lastIndexOf' (Pattern "\xD800") 1 str
-  --   , expected: Nothing
-  --   }
-  -- assertEqual
-  --   { actual: SCP.lastIndexOf' (Pattern "\xD800") 0 str
-  --   , expected: Nothing
-  --   }
-  -- assertEqual
-  --   { actual: SCP.lastIndexOf' (Pattern "\x16A06") 7 str
-  --   , expected: Just 5
-  --   }
-  -- assertEqual
-  --   { actual: SCP.lastIndexOf' (Pattern "\x16A06") 6 str
-  --   , expected: Just 5
-  --   }
-  -- assertEqual
-  --   { actual: SCP.lastIndexOf' (Pattern "\x16A06") 5 str
-  --   , expected: Just 5
-  --   }
-  -- assertEqual
-  --   { actual: SCP.lastIndexOf' (Pattern "\x16A06") 4 str
-  --   , expected: Nothing
-  --   }
-  -- assertEqual
-  --   { actual: SCP.lastIndexOf' (Pattern "\x16A06") 3 str
-  --   , expected: Nothing
-  --   }
+--   log "lastIndexOf'"
+--   assertEqual
+--     { actual: SCP.lastIndexOf' (Pattern "") 0 ""
+--     , expected: Just 0
+--     }
+--   -- assertEqual
+--   --   { actual: SCP.lastIndexOf' (Pattern str) 0 str
+--   --   , expected: Just 0
+--   --   }
+--   -- assertEqual
+--   --   { actual: SCP.lastIndexOf' (Pattern str) 1 str
+--   --   , expected: Just 0
+--   --   }
+--   -- assertEqual
+--   --   { actual: SCP.lastIndexOf' (Pattern "a") (-1) str
+--   --   , expected: Just 0
+--   --   }
+--   -- assertEqual
+--   --   { actual: SCP.lastIndexOf' (Pattern "a") 0 str
+--   --   , expected: Just 0
+--   --   }
+--   -- assertEqual
+--   --   { actual: SCP.lastIndexOf' (Pattern "a") 7 str
+--   --   , expected: Just 0
+--   --   }
+--   -- assertEqual
+--   --   { actual: SCP.lastIndexOf' (Pattern "a") (SCP.length str) str
+--   --   , expected: Just 0
+--   --   }
+--   -- assertEqual
+--   --   { actual: SCP.lastIndexOf' (Pattern "z") 0 str
+--   --   , expected: Nothing
+--   --   }
+--   -- assertEqual
+--   --   { actual: SCP.lastIndexOf' (Pattern "z") 1 str
+--   --   , expected: Nothing
+--   --   }
+--   -- assertEqual
+--   --   { actual: SCP.lastIndexOf' (Pattern "z") 2 str
+--   --   , expected: Nothing
+--   --   }
+--   -- assertEqual
+--   --   { actual: SCP.lastIndexOf' (Pattern "z") 3 str
+--   --   , expected: Nothing
+--   --   }
+--   -- assertEqual
+--   --   { actual: SCP.lastIndexOf' (Pattern "z") 4 str
+--   --   , expected: Nothing
+--   --   }
+--   -- assertEqual
+--   --   { actual: SCP.lastIndexOf' (Pattern "z") 5 str
+--   --   , expected: Nothing
+--   --   }
+--   -- assertEqual
+--   --   { actual: SCP.lastIndexOf' (Pattern "z") 6 str
+--   --   , expected: Just 6
+--   --   }
+--   -- assertEqual
+--   --   { actual: SCP.lastIndexOf' (Pattern "z") 7 str
+--   --   , expected: Just 6
+--   --   }
+--   -- assertEqual
+--   --   { actual: SCP.lastIndexOf' (Pattern "\xD800") 7 str
+--   --   , expected: Just 3
+--   --   }
+--   -- assertEqual
+--   --   { actual: SCP.lastIndexOf' (Pattern "\xD800") 6 str
+--   --   , expected: Just 3
+--   --   }
+--   -- assertEqual
+--   --   { actual: SCP.lastIndexOf' (Pattern "\xD800") 5 str
+--   --   , expected: Just 3
+--   --   }
+--   -- assertEqual
+--   --   { actual: SCP.lastIndexOf' (Pattern "\xD800") 4 str
+--   --   , expected: Just 3
+--   --   }
+--   -- assertEqual
+--   --   { actual: SCP.lastIndexOf' (Pattern "\xD800") 3 str
+--   --   , expected: Just 3
+--   --   }
+--   -- assertEqual
+--   --   { actual: SCP.lastIndexOf' (Pattern "\xD800") 2 str
+--   --   , expected: Just 2
+--   --   }
+--   -- assertEqual
+--   --   { actual: SCP.lastIndexOf' (Pattern "\xD800") 1 str
+--   --   , expected: Nothing
+--   --   }
+--   -- assertEqual
+--   --   { actual: SCP.lastIndexOf' (Pattern "\xD800") 0 str
+--   --   , expected: Nothing
+--   --   }
+--   -- assertEqual
+--   --   { actual: SCP.lastIndexOf' (Pattern "\x16A06") 7 str
+--   --   , expected: Just 5
+--   --   }
+--   -- assertEqual
+--   --   { actual: SCP.lastIndexOf' (Pattern "\x16A06") 6 str
+--   --   , expected: Just 5
+--   --   }
+--   -- assertEqual
+--   --   { actual: SCP.lastIndexOf' (Pattern "\x16A06") 5 str
+--   --   , expected: Just 5
+--   --   }
+--   -- assertEqual
+--   --   { actual: SCP.lastIndexOf' (Pattern "\x16A06") 4 str
+--   --   , expected: Nothing
+--   --   }
+--   -- assertEqual
+--   --   { actual: SCP.lastIndexOf' (Pattern "\x16A06") 3 str
+--   --   , expected: Nothing
+--   --   }
 
-  -- log "take"
-  -- assertEqual
-  --   { actual: SCP.take (-1) str
-  --   , expected: ""
-  --   }
-  -- assertEqual
-  --   { actual: SCP.take 0 str
-  --   , expected: ""
-  --   }
-  -- assertEqual
-  --   { actual: SCP.take 1 str
-  --   , expected: "a"
-  --   }
-  -- assertEqual
-  --   { actual: SCP.take 2 str
-  --   , expected: "a\xDC00"
-  --   }
-  -- assertEqual
-  --   { actual: SCP.take 3 str
-  --   , expected: "a\xDC00\xD800"
-  --   }
-  -- assertEqual
-  --   { actual: SCP.take 4 str
-  --   , expected: "a\xDC00\xD800\xD800"
-  --   }
-  -- assertEqual
-  --   { actual: SCP.take 5 str
-  --   , expected: "a\xDC00\xD800\xD800\x16805"
-  --   }
-  -- assertEqual
-  --   { actual: SCP.take 6 str
-  --   , expected: "a\xDC00\xD800\xD800\x16805\x16A06"
-  --   }
-  -- assertEqual
-  --   { actual: SCP.take 7 str
-  --   , expected: str
-  --   }
-  -- assertEqual
-  --   { actual: SCP.take 8 str
-  --   , expected: str
-  --   }
+--   -- log "take"
+--   -- assertEqual
+--   --   { actual: SCP.take (-1) str
+--   --   , expected: ""
+--   --   }
+--   -- assertEqual
+--   --   { actual: SCP.take 0 str
+--   --   , expected: ""
+--   --   }
+--   -- assertEqual
+--   --   { actual: SCP.take 1 str
+--   --   , expected: "a"
+--   --   }
+--   -- assertEqual
+--   --   { actual: SCP.take 2 str
+--   --   , expected: "a\xDC00"
+--   --   }
+--   -- assertEqual
+--   --   { actual: SCP.take 3 str
+--   --   , expected: "a\xDC00\xD800"
+--   --   }
+--   -- assertEqual
+--   --   { actual: SCP.take 4 str
+--   --   , expected: "a\xDC00\xD800\xD800"
+--   --   }
+--   -- assertEqual
+--   --   { actual: SCP.take 5 str
+--   --   , expected: "a\xDC00\xD800\xD800\x16805"
+--   --   }
+--   -- assertEqual
+--   --   { actual: SCP.take 6 str
+--   --   , expected: "a\xDC00\xD800\xD800\x16805\x16A06"
+--   --   }
+--   -- assertEqual
+--   --   { actual: SCP.take 7 str
+--   --   , expected: str
+--   --   }
+--   -- assertEqual
+--   --   { actual: SCP.take 8 str
+--   --   , expected: str
+--   --   }
 
-  -- log "takeWhile"
-  -- assertEqual
-  --   { actual: SCP.takeWhile (\_ -> true) str
-  --   , expected: str
-  --   }
-  -- assertEqual
-  --   { actual: SCP.takeWhile (\_ -> false) str
-  --   , expected: ""
-  --   }
-  -- assertEqual
-  --   { actual: SCP.takeWhile (\c -> fromEnum c < 0xFFFF) str
-  --   , expected: "a\xDC00\xD800\xD800"
-  --   }
-  -- assertEqual
-  --   { actual: SCP.takeWhile (\c -> fromEnum c < 0xDC00) str
-  --   , expected: "a"
-  --   }
+--   -- log "takeWhile"
+--   -- assertEqual
+--   --   { actual: SCP.takeWhile (\_ -> true) str
+--   --   , expected: str
+--   --   }
+--   -- assertEqual
+--   --   { actual: SCP.takeWhile (\_ -> false) str
+--   --   , expected: ""
+--   --   }
+--   -- assertEqual
+--   --   { actual: SCP.takeWhile (\c -> fromEnum c < 0xFFFF) str
+--   --   , expected: "a\xDC00\xD800\xD800"
+--   --   }
+--   -- assertEqual
+--   --   { actual: SCP.takeWhile (\c -> fromEnum c < 0xDC00) str
+--   --   , expected: "a"
+--   --   }
 
-  -- log "drop"
-  -- assertEqual
-  --   { actual: SCP.drop (-1) str
-  --   , expected: str
-  --   }
-  -- assertEqual
-  --   { actual: SCP.drop 0 str
-  --   , expected: str
-  --   }
-  -- assertEqual
-  --   { actual: SCP.drop 1 str
-  --   , expected: "\xDC00\xD800\xD800\x16805\x16A06z"
-  --   }
-  -- assertEqual
-  --   { actual: SCP.drop 2 str
-  --   , expected: "\xD800\xD800\x16805\x16A06z"
-  --   }
-  -- assertEqual
-  --   { actual: SCP.drop 3 str
-  --   , expected: "\xD800\x16805\x16A06z"
-  --   }
-  -- assertEqual
-  --   { actual: SCP.drop 4 str
-  --   , expected: "\x16805\x16A06z"
-  --   }
-  -- assertEqual
-  --   { actual: SCP.drop 5 str
-  --   , expected: "\x16A06z"
-  --   }
-  -- assertEqual
-  --   { actual: SCP.drop 6 str
-  --   , expected: "z"
-  --   }
-  -- assertEqual
-  --   { actual: SCP.drop 7 str
-  --   , expected: ""
-  --   }
-  -- assertEqual
-  --   { actual: SCP.drop 8 str
-  --   , expected: ""
-  --   }
+--   -- log "drop"
+--   -- assertEqual
+--   --   { actual: SCP.drop (-1) str
+--   --   , expected: str
+--   --   }
+--   -- assertEqual
+--   --   { actual: SCP.drop 0 str
+--   --   , expected: str
+--   --   }
+--   -- assertEqual
+--   --   { actual: SCP.drop 1 str
+--   --   , expected: "\xDC00\xD800\xD800\x16805\x16A06z"
+--   --   }
+--   -- assertEqual
+--   --   { actual: SCP.drop 2 str
+--   --   , expected: "\xD800\xD800\x16805\x16A06z"
+--   --   }
+--   -- assertEqual
+--   --   { actual: SCP.drop 3 str
+--   --   , expected: "\xD800\x16805\x16A06z"
+--   --   }
+--   -- assertEqual
+--   --   { actual: SCP.drop 4 str
+--   --   , expected: "\x16805\x16A06z"
+--   --   }
+--   -- assertEqual
+--   --   { actual: SCP.drop 5 str
+--   --   , expected: "\x16A06z"
+--   --   }
+--   -- assertEqual
+--   --   { actual: SCP.drop 6 str
+--   --   , expected: "z"
+--   --   }
+--   -- assertEqual
+--   --   { actual: SCP.drop 7 str
+--   --   , expected: ""
+--   --   }
+--   -- assertEqual
+--   --   { actual: SCP.drop 8 str
+--   --   , expected: ""
+--   --   }
 
-  -- log "dropWhile"
-  -- assertEqual
-  --   { actual: SCP.dropWhile (\_ -> true) str
-  --   , expected: ""
-  --   }
-  -- assertEqual
-  --   { actual: SCP.dropWhile (\_ -> false) str
-  --   , expected: str
-  --   }
-  -- assertEqual
-  --   { actual: SCP.dropWhile (\c -> fromEnum c < 0xFFFF) str
-  --   , expected: "\x16805\x16A06z"
-  --   }
-  -- assertEqual
-  --   { actual: SCP.dropWhile (\c -> fromEnum c < 0xDC00) str
-  --   , expected: "\xDC00\xD800\xD800\x16805\x16A06z"
-  --   }
+--   -- log "dropWhile"
+--   -- assertEqual
+--   --   { actual: SCP.dropWhile (\_ -> true) str
+--   --   , expected: ""
+--   --   }
+--   -- assertEqual
+--   --   { actual: SCP.dropWhile (\_ -> false) str
+--   --   , expected: str
+--   --   }
+--   -- assertEqual
+--   --   { actual: SCP.dropWhile (\c -> fromEnum c < 0xFFFF) str
+--   --   , expected: "\x16805\x16A06z"
+--   --   }
+--   -- assertEqual
+--   --   { actual: SCP.dropWhile (\c -> fromEnum c < 0xDC00) str
+--   --   , expected: "\xDC00\xD800\xD800\x16805\x16A06z"
+--   --   }
 
-  log "splitAt"
-  assertEqual
-    { actual: SCP.splitAt 0 ""
-    , expected: {before: "", after: "" }
-    }
-  assertEqual
-    { actual: SCP.splitAt 1 ""
-    , expected: {before: "", after: "" }
-    }
-  assertEqual
-    { actual: SCP.splitAt 0 "a"
-    , expected: {before: "", after: "a"}
-    }
-  assertEqual
-    { actual: SCP.splitAt 1 "ab"
-    , expected: {before: "a", after: "b"}
-    }
-  assertEqual
-    { actual: SCP.splitAt 3 "aabcc"
-    , expected: {before: "aab", after: "cc"}
-    }
-  assertEqual
-    { actual: SCP.splitAt (-1) "abc"
-    , expected: {before: "", after: "abc"}
-    }
-  -- assertEqual
-  --   { actual: SCP.splitAt 0 str
-  --   , expected: {before: "", after: str}
-  --   }
-  -- assertEqual
-  --   { actual: SCP.splitAt 1 str
-  --   , expected: {before: "a", after: "\xDC00\xD800\xD800\x16805\x16A06z"}
-  --   }
-  -- assertEqual
-  --   { actual: SCP.splitAt 2 str
-  --   , expected: {before: "a\xDC00", after: "\xD800\xD800\x16805\x16A06z"}
-  --   }
-  -- assertEqual
-  --   { actual: SCP.splitAt 3 str
-  --   , expected: {before: "a\xDC00\xD800", after: "\xD800\x16805\x16A06z"}
-  --   }
-  -- assertEqual
-  --   { actual: SCP.splitAt 4 str
-  --   , expected: {before: "a\xDC00\xD800\xD800", after: "\x16805\x16A06z"}
-  --   }
-  -- assertEqual
-  --   { actual: SCP.splitAt 5 str
-  --   , expected: {before: "a\xDC00\xD800\xD800\x16805", after: "\x16A06z"}
-  --   }
-  -- assertEqual
-  --   { actual: SCP.splitAt 6 str
-  --   , expected: {before: "a\xDC00\xD800\xD800\x16805\x16A06", after: "z"}
-  --   }
-  -- assertEqual
-  --   { actual: SCP.splitAt 7 str
-  --   , expected: {before: str, after: ""}
-  --   }
-  -- assertEqual
-  --   { actual: SCP.splitAt 8 str
-  --   , expected: {before: str, after: ""}
-  --   }
+--   log "splitAt"
+--   assertEqual
+--     { actual: SCP.splitAt 0 ""
+--     , expected: {before: "", after: "" }
+--     }
+--   assertEqual
+--     { actual: SCP.splitAt 1 ""
+--     , expected: {before: "", after: "" }
+--     }
+--   assertEqual
+--     { actual: SCP.splitAt 0 "a"
+--     , expected: {before: "", after: "a"}
+--     }
+--   assertEqual
+--     { actual: SCP.splitAt 1 "ab"
+--     , expected: {before: "a", after: "b"}
+--     }
+--   assertEqual
+--     { actual: SCP.splitAt 3 "aabcc"
+--     , expected: {before: "aab", after: "cc"}
+--     }
+--   assertEqual
+--     { actual: SCP.splitAt (-1) "abc"
+--     , expected: {before: "", after: "abc"}
+--     }
+--   -- assertEqual
+--   --   { actual: SCP.splitAt 0 str
+--   --   , expected: {before: "", after: str}
+--   --   }
+--   -- assertEqual
+--   --   { actual: SCP.splitAt 1 str
+--   --   , expected: {before: "a", after: "\xDC00\xD800\xD800\x16805\x16A06z"}
+--   --   }
+--   -- assertEqual
+--   --   { actual: SCP.splitAt 2 str
+--   --   , expected: {before: "a\xDC00", after: "\xD800\xD800\x16805\x16A06z"}
+--   --   }
+--   -- assertEqual
+--   --   { actual: SCP.splitAt 3 str
+--   --   , expected: {before: "a\xDC00\xD800", after: "\xD800\x16805\x16A06z"}
+--   --   }
+--   -- assertEqual
+--   --   { actual: SCP.splitAt 4 str
+--   --   , expected: {before: "a\xDC00\xD800\xD800", after: "\x16805\x16A06z"}
+--   --   }
+--   -- assertEqual
+--   --   { actual: SCP.splitAt 5 str
+--   --   , expected: {before: "a\xDC00\xD800\xD800\x16805", after: "\x16A06z"}
+--   --   }
+--   -- assertEqual
+--   --   { actual: SCP.splitAt 6 str
+--   --   , expected: {before: "a\xDC00\xD800\xD800\x16805\x16A06", after: "z"}
+--   --   }
+--   -- assertEqual
+--   --   { actual: SCP.splitAt 7 str
+--   --   , expected: {before: str, after: ""}
+--   --   }
+--   -- assertEqual
+--   --   { actual: SCP.splitAt 8 str
+--   --   , expected: {before: str, after: ""}
+--   --   }
 
--- cp :: Int -> SCP.CodePoint
--- cp = unsafePartial fromJust <<< toEnum
+-- -- cp :: Int -> SCP.CodePoint
+-- -- cp = unsafePartial fromJust <<< toEnum

--- a/test/Test/Data/String/CodePoints.purs
+++ b/test/Test/Data/String/CodePoints.purs
@@ -1,51 +1,59 @@
 module Test.Data.String.CodePoints (testStringCodePoints) where
 
+-- This module has a large portion of tests commented out because they involve
+-- a string containing lone surrogates. This is fine on JS backend because
+-- purs compiles PS code directly without involving corefn, but when attempting
+-- to compile to corefn it outputs an array of integers instead of a string,
+-- which corefn-consuming backends cannot handle.
+
 import Prelude
 
-import Data.Enum (fromEnum, toEnum)
-import Data.Maybe (Maybe(..), fromJust)
+-- import Data.Enum (fromEnum, toEnum)
+import Data.Enum (toEnum)
+-- import Data.Maybe (Maybe(..), fromJust)
+import Data.Maybe (Maybe(..))
 import Data.String.CodePoints as SCP
 import Data.String.Pattern (Pattern(..))
 import Effect (Effect)
 import Effect.Console (log)
-import Partial.Unsafe (unsafePartial)
+-- import Partial.Unsafe (unsafePartial)
 import Test.Assert (assertEqual)
 
-str :: String
-str = "a\xDC00\xD800\xD800\x16805\x16A06z"
+-- str :: String
+-- str = "a\xDC00\xD800\xD800\x16805\x16A06z"
 
 testStringCodePoints :: Effect Unit
 testStringCodePoints = do
 
-  log "show"
-  assertEqual
-    { actual: map show (SCP.codePointAt 0 str)
-    , expected: Just "(CodePoint 0x61)"
-    }
-  assertEqual
-    { actual: map show (SCP.codePointAt 1 str)
-    , expected: Just "(CodePoint 0xDC00)"
-    }
-  assertEqual
-    { actual: map show (SCP.codePointAt 2 str)
-    , expected: Just "(CodePoint 0xD800)"
-    }
-  assertEqual
-    { actual: map show (SCP.codePointAt 3 str)
-    , expected: Just "(CodePoint 0xD800)"
-    }
-  assertEqual
-    { actual: map show (SCP.codePointAt 4 str)
-    , expected: Just "(CodePoint 0x16805)"
-    }
-  assertEqual
-    { actual: map show (SCP.codePointAt 5 str)
-    , expected: Just "(CodePoint 0x16A06)"
-    }
-  assertEqual
-    { actual: map show (SCP.codePointAt 6 str)
-    , expected: Just "(CodePoint 0x7A)"
-    }
+  -- log "show"
+  -- assertEqual
+  --   { actual: map show (SCP.codePointAt 0 str)
+  --   , expected: Just "(CodePoint 0x61)"
+  --   }
+  -- assertEqual
+  --   { actual: map show (SCP.codePointAt 1 str)
+  --   , expected: Just "(CodePoint 0xDC00)"
+  --   }
+  -- assertEqual
+  --   { actual: map show (SCP.codePointAt 2 str)
+  --   , expected: Just "(CodePoint 0xD800)"
+  --   }
+  -- assertEqual
+  --   { actual: map show (SCP.codePointAt 3 str)
+  --   , expected: Just "(CodePoint 0xD800)"
+  --   }
+  -- assertEqual
+  --   { actual: map show (SCP.codePointAt 4 str)
+  --   , expected: Just "(CodePoint 0x16805)"
+  --   }
+  -- assertEqual
+  --   { actual: map show (SCP.codePointAt 5 str)
+  --   , expected: Just "(CodePoint 0x16A06)"
+  --   }
+  -- assertEqual
+  --   { actual: map show (SCP.codePointAt 6 str)
+  --   , expected: Just "(CodePoint 0x7A)"
+  --   }
 
   log "codePointFromChar"
   assertEqual
@@ -71,73 +79,73 @@ testStringCodePoints = do
     , expected: Just "\x16805"
     }
 
-  log "codePointAt"
-  assertEqual
-    { actual: SCP.codePointAt (-1) str
-    , expected: Nothing
-    }
-  assertEqual
-    { actual: SCP.codePointAt 0 str
-    , expected: (toEnum 0x61)
-    }
-  assertEqual
-    { actual: SCP.codePointAt 1 str
-    , expected: (toEnum 0xDC00)
-    }
-  assertEqual
-    { actual: SCP.codePointAt 2 str
-    , expected: (toEnum 0xD800)
-    }
-  assertEqual
-    { actual: SCP.codePointAt 3 str
-    , expected: (toEnum 0xD800)
-    }
-  assertEqual
-    { actual: SCP.codePointAt 4 str
-    , expected: (toEnum 0x16805)
-    }
-  assertEqual
-    { actual: SCP.codePointAt 5 str
-    , expected: (toEnum 0x16A06)
-    }
-  assertEqual
-    { actual: SCP.codePointAt 6 str
-    , expected: (toEnum 0x7A)
-    }
-  assertEqual
-    { actual: SCP.codePointAt 7 str
-    , expected: Nothing
-    }
+  -- log "codePointAt"
+  -- assertEqual
+  --   { actual: SCP.codePointAt (-1) str
+  --   , expected: Nothing
+  --   }
+  -- assertEqual
+  --   { actual: SCP.codePointAt 0 str
+  --   , expected: (toEnum 0x61)
+  --   }
+  -- assertEqual
+  --   { actual: SCP.codePointAt 1 str
+  --   , expected: (toEnum 0xDC00)
+  --   }
+  -- assertEqual
+  --   { actual: SCP.codePointAt 2 str
+  --   , expected: (toEnum 0xD800)
+  --   }
+  -- assertEqual
+  --   { actual: SCP.codePointAt 3 str
+  --   , expected: (toEnum 0xD800)
+  --   }
+  -- assertEqual
+  --   { actual: SCP.codePointAt 4 str
+  --   , expected: (toEnum 0x16805)
+  --   }
+  -- assertEqual
+  --   { actual: SCP.codePointAt 5 str
+  --   , expected: (toEnum 0x16A06)
+  --   }
+  -- assertEqual
+  --   { actual: SCP.codePointAt 6 str
+  --   , expected: (toEnum 0x7A)
+  --   }
+  -- assertEqual
+  --   { actual: SCP.codePointAt 7 str
+  --   , expected: Nothing
+  --   }
 
   log "uncons"
-  assertEqual
-    { actual: SCP.uncons str
-    , expected: Just {head: cp 0x61, tail:  "\xDC00\xD800\xD800\x16805\x16A06z"}
-    }
-  assertEqual
-    { actual: SCP.uncons (SCP.drop 1 str)
-    , expected: Just {head: cp 0xDC00, tail: "\xD800\xD800\x16805\x16A06z"}
-    }
-  assertEqual
-    { actual: SCP.uncons (SCP.drop 2 str)
-    , expected: Just {head: cp 0xD800, tail: "\xD800\x16805\x16A06z"}
-    }
-  assertEqual
-    { actual: SCP.uncons (SCP.drop 3 str)
-    , expected: Just {head: cp 0xD800, tail: "\x16805\x16A06z"}
-    }
-  assertEqual
-    { actual: SCP.uncons (SCP.drop 4 str)
-    , expected: Just {head: cp 0x16805, tail: "\x16A06z"}
-    }
-  assertEqual
-    { actual: SCP.uncons (SCP.drop 5 str)
-    , expected: Just {head: cp 0x16A06, tail: "z"}
-    }
-  assertEqual
-    { actual: SCP.uncons (SCP.drop 6 str)
-    , expected: Just {head: cp 0x7A, tail: ""}
-    }
+  -- assertEqual
+  --   { actual: SCP.uncons str
+  --   , expected: Just {head: cp 0x61, tail:  "\xDC00\xD800\xD800\x16805\x16A06z"}
+  --   }
+  -- assertEqual
+  --   { actual: SCP.uncons (SCP.drop 1 str)
+  --   , expected: Just {head: cp 0xDC00, tail: "\xD800\xD800\x16805\x16A06z"}
+  --   }
+  -- assertEqual
+  --   { actual: SCP.uncons (SCP.drop 2 str)
+  --   , expected: Just {head: cp 0xD800, tail: "\xD800\x16805\x16A06z"}
+  --   }
+  -- assertEqual
+  --   { actual: SCP.uncons (SCP.drop 3 str)
+  --   , expected: Just {head: cp 0xD800, tail: "\x16805\x16A06z"}
+  --   }
+  -- assertEqual
+  --   { actual: SCP.uncons (SCP.drop 4 str)
+  --   , expected: Just {head: cp 0x16805, tail: "\x16A06z"}
+  --   }
+  -- assertEqual
+  --   { actual: SCP.uncons (SCP.drop 5 str)
+  --   , expected: Just {head: cp 0x16A06, tail: "z"}
+  --   }
+  -- assertEqual
+  --   { actual: SCP.uncons (SCP.drop 6 str)
+  --   , expected: Just {head: cp 0x7A, tail: ""}
+  --   }
   assertEqual
     { actual: SCP.uncons ""
     , expected: Nothing
@@ -156,436 +164,436 @@ testStringCodePoints = do
     { actual: SCP.length "ab"
     , expected: 2
     }
-  assertEqual
-    { actual: SCP.length str
-    , expected: 7
-    }
+  -- assertEqual
+  --   { actual: SCP.length str
+  --   , expected: 7
+  --   }
 
   log "countPrefix"
   assertEqual
     { actual: SCP.countPrefix (\_ -> true) ""
     , expected: 0
     }
-  assertEqual
-    { actual: SCP.countPrefix (\_ -> false) str
-    , expected: 0
-    }
-  assertEqual
-    { actual: SCP.countPrefix (\_ -> true) str
-    , expected: 7
-    }
-  assertEqual
-    { actual: SCP.countPrefix (\x -> fromEnum x < 0xFFFF) str
-    , expected: 4
-    }
-  assertEqual
-    { actual: SCP.countPrefix (\x -> fromEnum x < 0xDC00) str
-    , expected: 1
-    }
+  -- assertEqual
+  --   { actual: SCP.countPrefix (\_ -> false) str
+  --   , expected: 0
+  --   }
+  -- assertEqual
+  --   { actual: SCP.countPrefix (\_ -> true) str
+  --   , expected: 7
+  --   }
+  -- assertEqual
+  --   { actual: SCP.countPrefix (\x -> fromEnum x < 0xFFFF) str
+  --   , expected: 4
+  --   }
+  -- assertEqual
+  --   { actual: SCP.countPrefix (\x -> fromEnum x < 0xDC00) str
+  --   , expected: 1
+  --   }
 
   log "indexOf"
   assertEqual
     { actual: SCP.indexOf (Pattern "") ""
     , expected: Just 0
     }
-  assertEqual
-    { actual: SCP.indexOf (Pattern "") str
-    , expected: Just 0
-    }
-  assertEqual
-    { actual: SCP.indexOf (Pattern str) str
-      , expected: Just 0
-      }
-  assertEqual
-    { actual: SCP.indexOf (Pattern "a") str
-    , expected: Just 0
-    }
-  assertEqual
-    { actual: SCP.indexOf (Pattern "\xDC00\xD800\xD800") str
-    , expected: Just 1
-    }
-  assertEqual
-    { actual: SCP.indexOf (Pattern "\xD800") str
-    , expected: Just 2
-    }
-  assertEqual
-    { actual: SCP.indexOf (Pattern "\xD800\xD800") str
-    , expected: Just 2
-    }
-  assertEqual
-    { actual: SCP.indexOf (Pattern "\xD800\xD81A") str
-    , expected: Just 3
-    }
-  assertEqual
-    { actual: SCP.indexOf (Pattern "\xD800\x16805") str
-    , expected: Just 3
-    }
-  assertEqual
-    { actual: SCP.indexOf (Pattern "\x16805") str
-    , expected: Just 4
-    }
-  assertEqual
-    { actual: SCP.indexOf (Pattern "\x16A06") str
-    , expected: Just 5
-    }
-  assertEqual
-    { actual: SCP.indexOf (Pattern "z") str
-    , expected: Just 6
-    }
-  assertEqual
-    { actual: SCP.indexOf (Pattern "\n") str
-    , expected: Nothing
-    }
-  assertEqual
-    { actual: SCP.indexOf (Pattern "\xD81A") str
-    , expected: Just 4
-    }
+  -- assertEqual
+  --   { actual: SCP.indexOf (Pattern "") str
+  --   , expected: Just 0
+  --   }
+  -- assertEqual
+  --   { actual: SCP.indexOf (Pattern str) str
+  --     , expected: Just 0
+  --     }
+  -- assertEqual
+  --   { actual: SCP.indexOf (Pattern "a") str
+  --   , expected: Just 0
+  --   }
+  -- assertEqual
+  --   { actual: SCP.indexOf (Pattern "\xDC00\xD800\xD800") str
+  --   , expected: Just 1
+  --   }
+  -- assertEqual
+  --   { actual: SCP.indexOf (Pattern "\xD800") str
+  --   , expected: Just 2
+  --   }
+  -- assertEqual
+  --   { actual: SCP.indexOf (Pattern "\xD800\xD800") str
+  --   , expected: Just 2
+  --   }
+  -- assertEqual
+  --   { actual: SCP.indexOf (Pattern "\xD800\xD81A") str
+  --   , expected: Just 3
+  --   }
+  -- assertEqual
+  --   { actual: SCP.indexOf (Pattern "\xD800\x16805") str
+  --   , expected: Just 3
+  --   }
+  -- assertEqual
+  --   { actual: SCP.indexOf (Pattern "\x16805") str
+  --   , expected: Just 4
+  --   }
+  -- assertEqual
+  --   { actual: SCP.indexOf (Pattern "\x16A06") str
+  --   , expected: Just 5
+  --   }
+  -- assertEqual
+  --   { actual: SCP.indexOf (Pattern "z") str
+  --   , expected: Just 6
+  --   }
+  -- assertEqual
+  --   { actual: SCP.indexOf (Pattern "\n") str
+  --   , expected: Nothing
+  --   }
+  -- assertEqual
+  --   { actual: SCP.indexOf (Pattern "\xD81A") str
+  --   , expected: Just 4
+  --   }
 
   log "indexOf'"
   assertEqual
     { actual: SCP.indexOf' (Pattern "") 0 ""
     , expected: Just 0
     }
-  assertEqual
-    { actual: SCP.indexOf' (Pattern str) 0 str
-    , expected: Just 0
-    }
-  assertEqual
-    { actual: SCP.indexOf' (Pattern str) 1 str
-    , expected: Nothing
-    }
-  assertEqual
-    { actual: SCP.indexOf' (Pattern "a") 0 str
-    , expected: Just 0
-    }
-  assertEqual
-    { actual: SCP.indexOf' (Pattern "a") 1 str
-    , expected: Nothing
-    }
-  assertEqual
-    { actual: SCP.indexOf' (Pattern "z") 0 str
-    , expected: Just 6
-    }
-  assertEqual
-    { actual: SCP.indexOf' (Pattern "z") 1 str
-    , expected: Just 6
-    }
-  assertEqual
-    { actual: SCP.indexOf' (Pattern "z") 2 str
-    , expected: Just 6
-    }
-  assertEqual
-    { actual: SCP.indexOf' (Pattern "z") 3 str
-    , expected: Just 6
-    }
-  assertEqual
-    { actual: SCP.indexOf' (Pattern "z") 4 str
-    , expected: Just 6
-    }
-  assertEqual
-    { actual: SCP.indexOf' (Pattern "z") 5 str
-    , expected: Just 6
-    }
-  assertEqual
-    { actual: SCP.indexOf' (Pattern "z") 6 str
-    , expected: Just 6
-    }
-  assertEqual
-    { actual: SCP.indexOf' (Pattern "z") 7 str
-    , expected: Nothing
-    }
+  -- assertEqual
+  --   { actual: SCP.indexOf' (Pattern str) 0 str
+  --   , expected: Just 0
+  --   }
+  -- assertEqual
+  --   { actual: SCP.indexOf' (Pattern str) 1 str
+  --   , expected: Nothing
+  --   }
+  -- assertEqual
+  --   { actual: SCP.indexOf' (Pattern "a") 0 str
+  --   , expected: Just 0
+  --   }
+  -- assertEqual
+  --   { actual: SCP.indexOf' (Pattern "a") 1 str
+  --   , expected: Nothing
+  --   }
+  -- assertEqual
+  --   { actual: SCP.indexOf' (Pattern "z") 0 str
+  --   , expected: Just 6
+  --   }
+  -- assertEqual
+  --   { actual: SCP.indexOf' (Pattern "z") 1 str
+  --   , expected: Just 6
+  --   }
+  -- assertEqual
+  --   { actual: SCP.indexOf' (Pattern "z") 2 str
+  --   , expected: Just 6
+  --   }
+  -- assertEqual
+  --   { actual: SCP.indexOf' (Pattern "z") 3 str
+  --   , expected: Just 6
+  --   }
+  -- assertEqual
+  --   { actual: SCP.indexOf' (Pattern "z") 4 str
+  --   , expected: Just 6
+  --   }
+  -- assertEqual
+  --   { actual: SCP.indexOf' (Pattern "z") 5 str
+  --   , expected: Just 6
+  --   }
+  -- assertEqual
+  --   { actual: SCP.indexOf' (Pattern "z") 6 str
+  --   , expected: Just 6
+  --   }
+  -- assertEqual
+  --   { actual: SCP.indexOf' (Pattern "z") 7 str
+  --   , expected: Nothing
+  --   }
 
   log "lastIndexOf"
   assertEqual
     { actual: SCP.lastIndexOf (Pattern "") ""
     , expected: Just 0
     }
-  assertEqual
-    { actual: SCP.lastIndexOf (Pattern "") str
-    , expected: Just 7
-    }
-  assertEqual
-    { actual: SCP.lastIndexOf (Pattern str) str
-    , expected: Just 0
-    }
-  assertEqual
-    { actual: SCP.lastIndexOf (Pattern "a") str
-    , expected: Just 0
-    }
-  assertEqual
-    { actual: SCP.lastIndexOf (Pattern "\xDC00\xD800\xD800") str
-    , expected: Just 1
-    }
-  assertEqual
-    { actual: SCP.lastIndexOf (Pattern "\xD800") str
-    , expected: Just 3
-    }
-  assertEqual
-    { actual: SCP.lastIndexOf (Pattern "\xD800\xD800") str
-    , expected: Just 2
-    }
-  assertEqual
-    { actual: SCP.lastIndexOf (Pattern "\xD800\xD81A") str
-    , expected: Just 3
-    }
-  assertEqual
-    { actual: SCP.lastIndexOf (Pattern "\xD800\x16805") str
-    , expected: Just 3
-    }
-  assertEqual
-    { actual: SCP.lastIndexOf (Pattern "\x16805") str
-    , expected: Just 4
-    }
-  assertEqual
-    { actual: SCP.lastIndexOf (Pattern "\x16A06") str
-    , expected: Just 5
-    }
-  assertEqual
-    { actual: SCP.lastIndexOf (Pattern "z") str
-    , expected: Just 6
-    }
-  assertEqual
-    { actual: SCP.lastIndexOf (Pattern "\n") str
-    , expected: Nothing
-    }
-  assertEqual
-    { actual: SCP.lastIndexOf (Pattern "\xD81A") str
-    , expected: Just 5
-    }
+  -- assertEqual
+  --   { actual: SCP.lastIndexOf (Pattern "") str
+  --   , expected: Just 7
+  --   }
+  -- assertEqual
+  --   { actual: SCP.lastIndexOf (Pattern str) str
+  --   , expected: Just 0
+  --   }
+  -- assertEqual
+  --   { actual: SCP.lastIndexOf (Pattern "a") str
+  --   , expected: Just 0
+  --   }
+  -- assertEqual
+  --   { actual: SCP.lastIndexOf (Pattern "\xDC00\xD800\xD800") str
+  --   , expected: Just 1
+  --   }
+  -- assertEqual
+  --   { actual: SCP.lastIndexOf (Pattern "\xD800") str
+  --   , expected: Just 3
+  --   }
+  -- assertEqual
+  --   { actual: SCP.lastIndexOf (Pattern "\xD800\xD800") str
+  --   , expected: Just 2
+  --   }
+  -- assertEqual
+  --   { actual: SCP.lastIndexOf (Pattern "\xD800\xD81A") str
+  --   , expected: Just 3
+  --   }
+  -- assertEqual
+  --   { actual: SCP.lastIndexOf (Pattern "\xD800\x16805") str
+  --   , expected: Just 3
+  --   }
+  -- assertEqual
+  --   { actual: SCP.lastIndexOf (Pattern "\x16805") str
+  --   , expected: Just 4
+  --   }
+  -- assertEqual
+  --   { actual: SCP.lastIndexOf (Pattern "\x16A06") str
+  --   , expected: Just 5
+  --   }
+  -- assertEqual
+  --   { actual: SCP.lastIndexOf (Pattern "z") str
+  --   , expected: Just 6
+  --   }
+  -- assertEqual
+  --   { actual: SCP.lastIndexOf (Pattern "\n") str
+  --   , expected: Nothing
+  --   }
+  -- assertEqual
+  --   { actual: SCP.lastIndexOf (Pattern "\xD81A") str
+  --   , expected: Just 5
+  --   }
 
   log "lastIndexOf'"
   assertEqual
     { actual: SCP.lastIndexOf' (Pattern "") 0 ""
     , expected: Just 0
     }
-  assertEqual
-    { actual: SCP.lastIndexOf' (Pattern str) 0 str
-    , expected: Just 0
-    }
-  assertEqual
-    { actual: SCP.lastIndexOf' (Pattern str) 1 str
-    , expected: Just 0
-    }
-  assertEqual
-    { actual: SCP.lastIndexOf' (Pattern "a") (-1) str
-    , expected: Just 0
-    }
-  assertEqual
-    { actual: SCP.lastIndexOf' (Pattern "a") 0 str
-    , expected: Just 0
-    }
-  assertEqual
-    { actual: SCP.lastIndexOf' (Pattern "a") 7 str
-    , expected: Just 0
-    }
-  assertEqual
-    { actual: SCP.lastIndexOf' (Pattern "a") (SCP.length str) str
-    , expected: Just 0
-    }
-  assertEqual
-    { actual: SCP.lastIndexOf' (Pattern "z") 0 str
-    , expected: Nothing
-    }
-  assertEqual
-    { actual: SCP.lastIndexOf' (Pattern "z") 1 str
-    , expected: Nothing
-    }
-  assertEqual
-    { actual: SCP.lastIndexOf' (Pattern "z") 2 str
-    , expected: Nothing
-    }
-  assertEqual
-    { actual: SCP.lastIndexOf' (Pattern "z") 3 str
-    , expected: Nothing
-    }
-  assertEqual
-    { actual: SCP.lastIndexOf' (Pattern "z") 4 str
-    , expected: Nothing
-    }
-  assertEqual
-    { actual: SCP.lastIndexOf' (Pattern "z") 5 str
-    , expected: Nothing
-    }
-  assertEqual
-    { actual: SCP.lastIndexOf' (Pattern "z") 6 str
-    , expected: Just 6
-    }
-  assertEqual
-    { actual: SCP.lastIndexOf' (Pattern "z") 7 str
-    , expected: Just 6
-    }
-  assertEqual
-    { actual: SCP.lastIndexOf' (Pattern "\xD800") 7 str
-    , expected: Just 3
-    }
-  assertEqual
-    { actual: SCP.lastIndexOf' (Pattern "\xD800") 6 str
-    , expected: Just 3
-    }
-  assertEqual
-    { actual: SCP.lastIndexOf' (Pattern "\xD800") 5 str
-    , expected: Just 3
-    }
-  assertEqual
-    { actual: SCP.lastIndexOf' (Pattern "\xD800") 4 str
-    , expected: Just 3
-    }
-  assertEqual
-    { actual: SCP.lastIndexOf' (Pattern "\xD800") 3 str
-    , expected: Just 3
-    }
-  assertEqual
-    { actual: SCP.lastIndexOf' (Pattern "\xD800") 2 str
-    , expected: Just 2
-    }
-  assertEqual
-    { actual: SCP.lastIndexOf' (Pattern "\xD800") 1 str
-    , expected: Nothing
-    }
-  assertEqual
-    { actual: SCP.lastIndexOf' (Pattern "\xD800") 0 str
-    , expected: Nothing
-    }
-  assertEqual
-    { actual: SCP.lastIndexOf' (Pattern "\x16A06") 7 str
-    , expected: Just 5
-    }
-  assertEqual
-    { actual: SCP.lastIndexOf' (Pattern "\x16A06") 6 str
-    , expected: Just 5
-    }
-  assertEqual
-    { actual: SCP.lastIndexOf' (Pattern "\x16A06") 5 str
-    , expected: Just 5
-    }
-  assertEqual
-    { actual: SCP.lastIndexOf' (Pattern "\x16A06") 4 str
-    , expected: Nothing
-    }
-  assertEqual
-    { actual: SCP.lastIndexOf' (Pattern "\x16A06") 3 str
-    , expected: Nothing
-    }
+  -- assertEqual
+  --   { actual: SCP.lastIndexOf' (Pattern str) 0 str
+  --   , expected: Just 0
+  --   }
+  -- assertEqual
+  --   { actual: SCP.lastIndexOf' (Pattern str) 1 str
+  --   , expected: Just 0
+  --   }
+  -- assertEqual
+  --   { actual: SCP.lastIndexOf' (Pattern "a") (-1) str
+  --   , expected: Just 0
+  --   }
+  -- assertEqual
+  --   { actual: SCP.lastIndexOf' (Pattern "a") 0 str
+  --   , expected: Just 0
+  --   }
+  -- assertEqual
+  --   { actual: SCP.lastIndexOf' (Pattern "a") 7 str
+  --   , expected: Just 0
+  --   }
+  -- assertEqual
+  --   { actual: SCP.lastIndexOf' (Pattern "a") (SCP.length str) str
+  --   , expected: Just 0
+  --   }
+  -- assertEqual
+  --   { actual: SCP.lastIndexOf' (Pattern "z") 0 str
+  --   , expected: Nothing
+  --   }
+  -- assertEqual
+  --   { actual: SCP.lastIndexOf' (Pattern "z") 1 str
+  --   , expected: Nothing
+  --   }
+  -- assertEqual
+  --   { actual: SCP.lastIndexOf' (Pattern "z") 2 str
+  --   , expected: Nothing
+  --   }
+  -- assertEqual
+  --   { actual: SCP.lastIndexOf' (Pattern "z") 3 str
+  --   , expected: Nothing
+  --   }
+  -- assertEqual
+  --   { actual: SCP.lastIndexOf' (Pattern "z") 4 str
+  --   , expected: Nothing
+  --   }
+  -- assertEqual
+  --   { actual: SCP.lastIndexOf' (Pattern "z") 5 str
+  --   , expected: Nothing
+  --   }
+  -- assertEqual
+  --   { actual: SCP.lastIndexOf' (Pattern "z") 6 str
+  --   , expected: Just 6
+  --   }
+  -- assertEqual
+  --   { actual: SCP.lastIndexOf' (Pattern "z") 7 str
+  --   , expected: Just 6
+  --   }
+  -- assertEqual
+  --   { actual: SCP.lastIndexOf' (Pattern "\xD800") 7 str
+  --   , expected: Just 3
+  --   }
+  -- assertEqual
+  --   { actual: SCP.lastIndexOf' (Pattern "\xD800") 6 str
+  --   , expected: Just 3
+  --   }
+  -- assertEqual
+  --   { actual: SCP.lastIndexOf' (Pattern "\xD800") 5 str
+  --   , expected: Just 3
+  --   }
+  -- assertEqual
+  --   { actual: SCP.lastIndexOf' (Pattern "\xD800") 4 str
+  --   , expected: Just 3
+  --   }
+  -- assertEqual
+  --   { actual: SCP.lastIndexOf' (Pattern "\xD800") 3 str
+  --   , expected: Just 3
+  --   }
+  -- assertEqual
+  --   { actual: SCP.lastIndexOf' (Pattern "\xD800") 2 str
+  --   , expected: Just 2
+  --   }
+  -- assertEqual
+  --   { actual: SCP.lastIndexOf' (Pattern "\xD800") 1 str
+  --   , expected: Nothing
+  --   }
+  -- assertEqual
+  --   { actual: SCP.lastIndexOf' (Pattern "\xD800") 0 str
+  --   , expected: Nothing
+  --   }
+  -- assertEqual
+  --   { actual: SCP.lastIndexOf' (Pattern "\x16A06") 7 str
+  --   , expected: Just 5
+  --   }
+  -- assertEqual
+  --   { actual: SCP.lastIndexOf' (Pattern "\x16A06") 6 str
+  --   , expected: Just 5
+  --   }
+  -- assertEqual
+  --   { actual: SCP.lastIndexOf' (Pattern "\x16A06") 5 str
+  --   , expected: Just 5
+  --   }
+  -- assertEqual
+  --   { actual: SCP.lastIndexOf' (Pattern "\x16A06") 4 str
+  --   , expected: Nothing
+  --   }
+  -- assertEqual
+  --   { actual: SCP.lastIndexOf' (Pattern "\x16A06") 3 str
+  --   , expected: Nothing
+  --   }
 
-  log "take"
-  assertEqual
-    { actual: SCP.take (-1) str
-    , expected: ""
-    }
-  assertEqual
-    { actual: SCP.take 0 str
-    , expected: ""
-    }
-  assertEqual
-    { actual: SCP.take 1 str
-    , expected: "a"
-    }
-  assertEqual
-    { actual: SCP.take 2 str
-    , expected: "a\xDC00"
-    }
-  assertEqual
-    { actual: SCP.take 3 str
-    , expected: "a\xDC00\xD800"
-    }
-  assertEqual
-    { actual: SCP.take 4 str
-    , expected: "a\xDC00\xD800\xD800"
-    }
-  assertEqual
-    { actual: SCP.take 5 str
-    , expected: "a\xDC00\xD800\xD800\x16805"
-    }
-  assertEqual
-    { actual: SCP.take 6 str
-    , expected: "a\xDC00\xD800\xD800\x16805\x16A06"
-    }
-  assertEqual
-    { actual: SCP.take 7 str
-    , expected: str
-    }
-  assertEqual
-    { actual: SCP.take 8 str
-    , expected: str
-    }
+  -- log "take"
+  -- assertEqual
+  --   { actual: SCP.take (-1) str
+  --   , expected: ""
+  --   }
+  -- assertEqual
+  --   { actual: SCP.take 0 str
+  --   , expected: ""
+  --   }
+  -- assertEqual
+  --   { actual: SCP.take 1 str
+  --   , expected: "a"
+  --   }
+  -- assertEqual
+  --   { actual: SCP.take 2 str
+  --   , expected: "a\xDC00"
+  --   }
+  -- assertEqual
+  --   { actual: SCP.take 3 str
+  --   , expected: "a\xDC00\xD800"
+  --   }
+  -- assertEqual
+  --   { actual: SCP.take 4 str
+  --   , expected: "a\xDC00\xD800\xD800"
+  --   }
+  -- assertEqual
+  --   { actual: SCP.take 5 str
+  --   , expected: "a\xDC00\xD800\xD800\x16805"
+  --   }
+  -- assertEqual
+  --   { actual: SCP.take 6 str
+  --   , expected: "a\xDC00\xD800\xD800\x16805\x16A06"
+  --   }
+  -- assertEqual
+  --   { actual: SCP.take 7 str
+  --   , expected: str
+  --   }
+  -- assertEqual
+  --   { actual: SCP.take 8 str
+  --   , expected: str
+  --   }
 
-  log "takeWhile"
-  assertEqual
-    { actual: SCP.takeWhile (\_ -> true) str
-    , expected: str
-    }
-  assertEqual
-    { actual: SCP.takeWhile (\_ -> false) str
-    , expected: ""
-    }
-  assertEqual
-    { actual: SCP.takeWhile (\c -> fromEnum c < 0xFFFF) str
-    , expected: "a\xDC00\xD800\xD800"
-    }
-  assertEqual
-    { actual: SCP.takeWhile (\c -> fromEnum c < 0xDC00) str
-    , expected: "a"
-    }
+  -- log "takeWhile"
+  -- assertEqual
+  --   { actual: SCP.takeWhile (\_ -> true) str
+  --   , expected: str
+  --   }
+  -- assertEqual
+  --   { actual: SCP.takeWhile (\_ -> false) str
+  --   , expected: ""
+  --   }
+  -- assertEqual
+  --   { actual: SCP.takeWhile (\c -> fromEnum c < 0xFFFF) str
+  --   , expected: "a\xDC00\xD800\xD800"
+  --   }
+  -- assertEqual
+  --   { actual: SCP.takeWhile (\c -> fromEnum c < 0xDC00) str
+  --   , expected: "a"
+  --   }
 
-  log "drop"
-  assertEqual
-    { actual: SCP.drop (-1) str
-    , expected: str
-    }
-  assertEqual
-    { actual: SCP.drop 0 str
-    , expected: str
-    }
-  assertEqual
-    { actual: SCP.drop 1 str
-    , expected: "\xDC00\xD800\xD800\x16805\x16A06z"
-    }
-  assertEqual
-    { actual: SCP.drop 2 str
-    , expected: "\xD800\xD800\x16805\x16A06z"
-    }
-  assertEqual
-    { actual: SCP.drop 3 str
-    , expected: "\xD800\x16805\x16A06z"
-    }
-  assertEqual
-    { actual: SCP.drop 4 str
-    , expected: "\x16805\x16A06z"
-    }
-  assertEqual
-    { actual: SCP.drop 5 str
-    , expected: "\x16A06z"
-    }
-  assertEqual
-    { actual: SCP.drop 6 str
-    , expected: "z"
-    }
-  assertEqual
-    { actual: SCP.drop 7 str
-    , expected: ""
-    }
-  assertEqual
-    { actual: SCP.drop 8 str
-    , expected: ""
-    }
+  -- log "drop"
+  -- assertEqual
+  --   { actual: SCP.drop (-1) str
+  --   , expected: str
+  --   }
+  -- assertEqual
+  --   { actual: SCP.drop 0 str
+  --   , expected: str
+  --   }
+  -- assertEqual
+  --   { actual: SCP.drop 1 str
+  --   , expected: "\xDC00\xD800\xD800\x16805\x16A06z"
+  --   }
+  -- assertEqual
+  --   { actual: SCP.drop 2 str
+  --   , expected: "\xD800\xD800\x16805\x16A06z"
+  --   }
+  -- assertEqual
+  --   { actual: SCP.drop 3 str
+  --   , expected: "\xD800\x16805\x16A06z"
+  --   }
+  -- assertEqual
+  --   { actual: SCP.drop 4 str
+  --   , expected: "\x16805\x16A06z"
+  --   }
+  -- assertEqual
+  --   { actual: SCP.drop 5 str
+  --   , expected: "\x16A06z"
+  --   }
+  -- assertEqual
+  --   { actual: SCP.drop 6 str
+  --   , expected: "z"
+  --   }
+  -- assertEqual
+  --   { actual: SCP.drop 7 str
+  --   , expected: ""
+  --   }
+  -- assertEqual
+  --   { actual: SCP.drop 8 str
+  --   , expected: ""
+  --   }
 
-  log "dropWhile"
-  assertEqual
-    { actual: SCP.dropWhile (\_ -> true) str
-    , expected: ""
-    }
-  assertEqual
-    { actual: SCP.dropWhile (\_ -> false) str
-    , expected: str
-    }
-  assertEqual
-    { actual: SCP.dropWhile (\c -> fromEnum c < 0xFFFF) str
-    , expected: "\x16805\x16A06z"
-    }
-  assertEqual
-    { actual: SCP.dropWhile (\c -> fromEnum c < 0xDC00) str
-    , expected: "\xDC00\xD800\xD800\x16805\x16A06z"
-    }
+  -- log "dropWhile"
+  -- assertEqual
+  --   { actual: SCP.dropWhile (\_ -> true) str
+  --   , expected: ""
+  --   }
+  -- assertEqual
+  --   { actual: SCP.dropWhile (\_ -> false) str
+  --   , expected: str
+  --   }
+  -- assertEqual
+  --   { actual: SCP.dropWhile (\c -> fromEnum c < 0xFFFF) str
+  --   , expected: "\x16805\x16A06z"
+  --   }
+  -- assertEqual
+  --   { actual: SCP.dropWhile (\c -> fromEnum c < 0xDC00) str
+  --   , expected: "\xDC00\xD800\xD800\x16805\x16A06z"
+  --   }
 
   log "splitAt"
   assertEqual
@@ -612,42 +620,42 @@ testStringCodePoints = do
     { actual: SCP.splitAt (-1) "abc"
     , expected: {before: "", after: "abc"}
     }
-  assertEqual
-    { actual: SCP.splitAt 0 str
-    , expected: {before: "", after: str}
-    }
-  assertEqual
-    { actual: SCP.splitAt 1 str
-    , expected: {before: "a", after: "\xDC00\xD800\xD800\x16805\x16A06z"}
-    }
-  assertEqual
-    { actual: SCP.splitAt 2 str
-    , expected: {before: "a\xDC00", after: "\xD800\xD800\x16805\x16A06z"}
-    }
-  assertEqual
-    { actual: SCP.splitAt 3 str
-    , expected: {before: "a\xDC00\xD800", after: "\xD800\x16805\x16A06z"}
-    }
-  assertEqual
-    { actual: SCP.splitAt 4 str
-    , expected: {before: "a\xDC00\xD800\xD800", after: "\x16805\x16A06z"}
-    }
-  assertEqual
-    { actual: SCP.splitAt 5 str
-    , expected: {before: "a\xDC00\xD800\xD800\x16805", after: "\x16A06z"}
-    }
-  assertEqual
-    { actual: SCP.splitAt 6 str
-    , expected: {before: "a\xDC00\xD800\xD800\x16805\x16A06", after: "z"}
-    }
-  assertEqual
-    { actual: SCP.splitAt 7 str
-    , expected: {before: str, after: ""}
-    }
-  assertEqual
-    { actual: SCP.splitAt 8 str
-    , expected: {before: str, after: ""}
-    }
+  -- assertEqual
+  --   { actual: SCP.splitAt 0 str
+  --   , expected: {before: "", after: str}
+  --   }
+  -- assertEqual
+  --   { actual: SCP.splitAt 1 str
+  --   , expected: {before: "a", after: "\xDC00\xD800\xD800\x16805\x16A06z"}
+  --   }
+  -- assertEqual
+  --   { actual: SCP.splitAt 2 str
+  --   , expected: {before: "a\xDC00", after: "\xD800\xD800\x16805\x16A06z"}
+  --   }
+  -- assertEqual
+  --   { actual: SCP.splitAt 3 str
+  --   , expected: {before: "a\xDC00\xD800", after: "\xD800\x16805\x16A06z"}
+  --   }
+  -- assertEqual
+  --   { actual: SCP.splitAt 4 str
+  --   , expected: {before: "a\xDC00\xD800\xD800", after: "\x16805\x16A06z"}
+  --   }
+  -- assertEqual
+  --   { actual: SCP.splitAt 5 str
+  --   , expected: {before: "a\xDC00\xD800\xD800\x16805", after: "\x16A06z"}
+  --   }
+  -- assertEqual
+  --   { actual: SCP.splitAt 6 str
+  --   , expected: {before: "a\xDC00\xD800\xD800\x16805\x16A06", after: "z"}
+  --   }
+  -- assertEqual
+  --   { actual: SCP.splitAt 7 str
+  --   , expected: {before: str, after: ""}
+  --   }
+  -- assertEqual
+  --   { actual: SCP.splitAt 8 str
+  --   , expected: {before: str, after: ""}
+  --   }
 
-cp :: Int -> SCP.CodePoint
-cp = unsafePartial fromJust <<< toEnum
+-- cp :: Int -> SCP.CodePoint
+-- cp = unsafePartial fromJust <<< toEnum

--- a/test/Test/Data/String/CodeUnits.purs
+++ b/test/Test/Data/String/CodeUnits.purs
@@ -1,516 +1,517 @@
-module Test.Data.String.CodeUnits (testStringCodeUnits) where
+-- module Test.Data.String.CodeUnits (testStringCodeUnits) where
+module Test.Data.String.CodeUnits where
 
-import Prelude
+-- import Prelude
 
-import Data.Enum (fromEnum)
-import Data.Maybe (Maybe(..), isNothing)
-import Data.String.CodeUnits as SCU
-import Data.String.Pattern (Pattern(..))
-import Effect (Effect)
-import Effect.Console (log)
-import Test.Assert (assert, assertEqual)
+-- import Data.Enum (fromEnum)
+-- import Data.Maybe (Maybe(..), isNothing)
+-- import Data.String.CodeUnits as SCU
+-- import Data.String.Pattern (Pattern(..))
+-- import Effect (Effect)
+-- import Effect.Console (log)
+-- import Test.Assert (assert, assertEqual)
 
-testStringCodeUnits :: Effect Unit
-testStringCodeUnits = do
-  log "stripPrefix"
-  assertEqual
-    { actual: SCU.stripPrefix (Pattern "abc") "abcde"
-    , expected: Just "de"
-    }
-  assertEqual
-    { actual: SCU.stripPrefix (Pattern "xyz") "abcde"
-    , expected: Nothing
-    }
-  assertEqual
-    { actual: SCU.stripPrefix (Pattern "abcd") "ab"
-    , expected: Nothing
-    }
-  assertEqual
-    { actual: SCU.stripPrefix (Pattern "abc") "abc"
-    , expected: Just ""
-    }
-  assertEqual
-    { actual: SCU.stripPrefix (Pattern "") "abc"
-    , expected: Just "abc"
-    }
-  assertEqual
-    { actual: SCU.stripPrefix (Pattern "") ""
-    , expected: Just ""
-    }
+-- testStringCodeUnits :: Effect Unit
+-- testStringCodeUnits = do
+--   log "stripPrefix"
+--   assertEqual
+--     { actual: SCU.stripPrefix (Pattern "abc") "abcde"
+--     , expected: Just "de"
+--     }
+--   assertEqual
+--     { actual: SCU.stripPrefix (Pattern "xyz") "abcde"
+--     , expected: Nothing
+--     }
+--   assertEqual
+--     { actual: SCU.stripPrefix (Pattern "abcd") "ab"
+--     , expected: Nothing
+--     }
+--   assertEqual
+--     { actual: SCU.stripPrefix (Pattern "abc") "abc"
+--     , expected: Just ""
+--     }
+--   assertEqual
+--     { actual: SCU.stripPrefix (Pattern "") "abc"
+--     , expected: Just "abc"
+--     }
+--   assertEqual
+--     { actual: SCU.stripPrefix (Pattern "") ""
+--     , expected: Just ""
+--     }
 
-  log "stripSuffix"
-  assertEqual
-    { actual: SCU.stripSuffix (Pattern "cde") "abcde"
-    , expected: Just "ab"
-    }
-  assertEqual
-    { actual: SCU.stripSuffix (Pattern "xyz") "abcde"
-    , expected: Nothing
-    }
-  assertEqual
-    { actual: SCU.stripSuffix (Pattern "abcd") "cd"
-    , expected: Nothing
-    }
-  assertEqual
-    { actual: SCU.stripSuffix (Pattern "abc") "abc"
-    , expected: Just ""
-    }
-  assertEqual
-    { actual: SCU.stripSuffix (Pattern "") "abc"
-    , expected: Just "abc"
-    }
-  assertEqual
-    { actual: SCU.stripSuffix (Pattern "") ""
-    , expected: Just ""
-    }
+--   log "stripSuffix"
+--   assertEqual
+--     { actual: SCU.stripSuffix (Pattern "cde") "abcde"
+--     , expected: Just "ab"
+--     }
+--   assertEqual
+--     { actual: SCU.stripSuffix (Pattern "xyz") "abcde"
+--     , expected: Nothing
+--     }
+--   assertEqual
+--     { actual: SCU.stripSuffix (Pattern "abcd") "cd"
+--     , expected: Nothing
+--     }
+--   assertEqual
+--     { actual: SCU.stripSuffix (Pattern "abc") "abc"
+--     , expected: Just ""
+--     }
+--   assertEqual
+--     { actual: SCU.stripSuffix (Pattern "") "abc"
+--     , expected: Just "abc"
+--     }
+--   assertEqual
+--     { actual: SCU.stripSuffix (Pattern "") ""
+--     , expected: Just ""
+--     }
 
-  log "charAt"
-  assertEqual
-    { actual: SCU.charAt 0 ""
-    , expected: Nothing
-    }
-  assertEqual
-    { actual: SCU.charAt 0 "a"
-    , expected: Just 'a'
-    }
-  assertEqual
-    { actual: SCU.charAt 1 "a"
-    , expected: Nothing
-    }
-  assertEqual
-    { actual: SCU.charAt 0 "ab"
-    , expected: Just 'a'
-    }
-  assertEqual
-    { actual: SCU.charAt 1 "ab"
-    , expected: Just 'b'
-    }
-  assertEqual
-    { actual: SCU.charAt 2 "ab"
-    , expected: Nothing
-    }
+--   log "charAt"
+--   assertEqual
+--     { actual: SCU.charAt 0 ""
+--     , expected: Nothing
+--     }
+--   assertEqual
+--     { actual: SCU.charAt 0 "a"
+--     , expected: Just 'a'
+--     }
+--   assertEqual
+--     { actual: SCU.charAt 1 "a"
+--     , expected: Nothing
+--     }
+--   assertEqual
+--     { actual: SCU.charAt 0 "ab"
+--     , expected: Just 'a'
+--     }
+--   assertEqual
+--     { actual: SCU.charAt 1 "ab"
+--     , expected: Just 'b'
+--     }
+--   assertEqual
+--     { actual: SCU.charAt 2 "ab"
+--     , expected: Nothing
+--     }
 
-  log "singleton"
-  assertEqual
-    { actual: SCU.singleton 'a'
-    , expected: "a"
-    }
+--   log "singleton"
+--   assertEqual
+--     { actual: SCU.singleton 'a'
+--     , expected: "a"
+--     }
 
-  log "charCodeAt"
-  assertEqual
-    { actual: (fromEnum <$> SCU.charAt 0 "")
-    , expected: Nothing
-    }
-  assertEqual
-    { actual: (fromEnum <$> SCU.charAt 0 "a")
-    , expected: Just 97
-    }
-  assertEqual
-    { actual: (fromEnum <$> SCU.charAt 1 "a")
-    , expected: Nothing
-    }
-  assertEqual
-    { actual: (fromEnum <$> SCU.charAt 0 "ab")
-    , expected: Just 97
-    }
-  assertEqual
-    { actual: (fromEnum <$> SCU.charAt 1 "ab")
-    , expected: Just 98
-    }
-  assertEqual
-    { actual: (fromEnum <$> SCU.charAt 2 "ab")
-    , expected: Nothing
-    }
+--   log "charCodeAt"
+--   assertEqual
+--     { actual: (fromEnum <$> SCU.charAt 0 "")
+--     , expected: Nothing
+--     }
+--   assertEqual
+--     { actual: (fromEnum <$> SCU.charAt 0 "a")
+--     , expected: Just 97
+--     }
+--   assertEqual
+--     { actual: (fromEnum <$> SCU.charAt 1 "a")
+--     , expected: Nothing
+--     }
+--   assertEqual
+--     { actual: (fromEnum <$> SCU.charAt 0 "ab")
+--     , expected: Just 97
+--     }
+--   assertEqual
+--     { actual: (fromEnum <$> SCU.charAt 1 "ab")
+--     , expected: Just 98
+--     }
+--   assertEqual
+--     { actual: (fromEnum <$> SCU.charAt 2 "ab")
+--     , expected: Nothing
+--     }
 
-  log "toChar"
-  assertEqual
-    { actual: SCU.toChar ""
-    , expected: Nothing
-    }
-  assertEqual
-    { actual: SCU.toChar "a"
-    , expected: Just 'a'
-    }
-  assertEqual
-    { actual: SCU.toChar "ab"
-    , expected: Nothing
-    }
+--   log "toChar"
+--   assertEqual
+--     { actual: SCU.toChar ""
+--     , expected: Nothing
+--     }
+--   assertEqual
+--     { actual: SCU.toChar "a"
+--     , expected: Just 'a'
+--     }
+--   assertEqual
+--     { actual: SCU.toChar "ab"
+--     , expected: Nothing
+--     }
 
-  log "uncons"
-  assert $ isNothing (SCU.uncons "")
-  assertEqual
-    { actual: SCU.uncons "a"
-    , expected: Just { head: 'a', tail: "" }
-    }
-  assertEqual
-    { actual: SCU.uncons "ab"
-    , expected: Just { head: 'a', tail: "b" }
-    }
+--   log "uncons"
+--   assert $ isNothing (SCU.uncons "")
+--   assertEqual
+--     { actual: SCU.uncons "a"
+--     , expected: Just { head: 'a', tail: "" }
+--     }
+--   assertEqual
+--     { actual: SCU.uncons "ab"
+--     , expected: Just { head: 'a', tail: "b" }
+--     }
 
-  log "takeWhile"
-  assertEqual
-    { actual: SCU.takeWhile (\c -> true) "abc"
-    , expected: "abc"
-    }
-  assertEqual
-    { actual: SCU.takeWhile (\c -> false) "abc"
-    , expected: ""
-    }
-  assertEqual
-    { actual: SCU.takeWhile (\c -> c /= 'b') "aabbcc"
-    , expected: "aa"
-    }
+--   log "takeWhile"
+--   assertEqual
+--     { actual: SCU.takeWhile (\c -> true) "abc"
+--     , expected: "abc"
+--     }
+--   assertEqual
+--     { actual: SCU.takeWhile (\c -> false) "abc"
+--     , expected: ""
+--     }
+--   assertEqual
+--     { actual: SCU.takeWhile (\c -> c /= 'b') "aabbcc"
+--     , expected: "aa"
+--     }
 
-  log "dropWhile"
-  assertEqual
-    { actual: SCU.dropWhile (\c -> true) "abc"
-    , expected: ""
-    }
-  assertEqual
-    { actual: SCU.dropWhile (\c -> false) "abc"
-    , expected: "abc"
-    }
-  assertEqual
-    { actual: SCU.dropWhile (\c -> c /= 'b') "aabbcc"
-    , expected: "bbcc"
-    }
+--   log "dropWhile"
+--   assertEqual
+--     { actual: SCU.dropWhile (\c -> true) "abc"
+--     , expected: ""
+--     }
+--   assertEqual
+--     { actual: SCU.dropWhile (\c -> false) "abc"
+--     , expected: "abc"
+--     }
+--   assertEqual
+--     { actual: SCU.dropWhile (\c -> c /= 'b') "aabbcc"
+--     , expected: "bbcc"
+--     }
 
-  log "fromCharArray"
-  assertEqual
-    { actual: SCU.fromCharArray []
-      , expected: ""
-      }
-  assertEqual
-    { actual: SCU.fromCharArray ['a', 'b']
-    , expected: "ab"
-    }
+--   log "fromCharArray"
+--   assertEqual
+--     { actual: SCU.fromCharArray []
+--       , expected: ""
+--       }
+--   assertEqual
+--     { actual: SCU.fromCharArray ['a', 'b']
+--     , expected: "ab"
+--     }
 
-  log "indexOf"
-  assertEqual
-    { actual: SCU.indexOf (Pattern "") ""
-    , expected: Just 0
-    }
-  assertEqual
-    { actual: SCU.indexOf (Pattern "") "abcd"
-    , expected: Just 0
-    }
-  assertEqual
-    { actual: SCU.indexOf (Pattern "bc") "abcd"
-    , expected: Just 1
-    }
-  assertEqual
-    { actual: SCU.indexOf (Pattern "cb") "abcd"
-    , expected: Nothing
-    }
+--   log "indexOf"
+--   assertEqual
+--     { actual: SCU.indexOf (Pattern "") ""
+--     , expected: Just 0
+--     }
+--   assertEqual
+--     { actual: SCU.indexOf (Pattern "") "abcd"
+--     , expected: Just 0
+--     }
+--   assertEqual
+--     { actual: SCU.indexOf (Pattern "bc") "abcd"
+--     , expected: Just 1
+--     }
+--   assertEqual
+--     { actual: SCU.indexOf (Pattern "cb") "abcd"
+--     , expected: Nothing
+--     }
 
-  log "indexOf'"
-  assertEqual
-    { actual: SCU.indexOf' (Pattern "") 0 ""
-    , expected: Just 0
-    }
-  assertEqual
-    { actual: SCU.indexOf' (Pattern "") (-1) "ab"
-    , expected: Nothing
-    }
-  assertEqual
-    { actual: SCU.indexOf' (Pattern "") 0 "ab"
-    , expected: Just 0
-    }
-  assertEqual
-    { actual: SCU.indexOf' (Pattern "") 1 "ab"
-    , expected: Just 1
-    }
-  assertEqual
-    { actual: SCU.indexOf' (Pattern "") 2 "ab"
-    , expected: Just 2
-    }
-  assertEqual
-    { actual: SCU.indexOf' (Pattern "") 3 "ab"
-    , expected: Nothing
-    }
-  assertEqual
-    { actual: SCU.indexOf' (Pattern "bc") 0 "abcd"
-    , expected: Just 1
-    }
-  assertEqual
-    { actual: SCU.indexOf' (Pattern "bc") 1 "abcd"
-    , expected: Just 1
-    }
-  assertEqual
-    { actual: SCU.indexOf' (Pattern "bc") 2 "abcd"
-    , expected: Nothing
-    }
-  assertEqual
-    { actual: SCU.indexOf' (Pattern "cb") 0 "abcd"
-    , expected: Nothing
-    }
+--   log "indexOf'"
+--   assertEqual
+--     { actual: SCU.indexOf' (Pattern "") 0 ""
+--     , expected: Just 0
+--     }
+--   assertEqual
+--     { actual: SCU.indexOf' (Pattern "") (-1) "ab"
+--     , expected: Nothing
+--     }
+--   assertEqual
+--     { actual: SCU.indexOf' (Pattern "") 0 "ab"
+--     , expected: Just 0
+--     }
+--   assertEqual
+--     { actual: SCU.indexOf' (Pattern "") 1 "ab"
+--     , expected: Just 1
+--     }
+--   assertEqual
+--     { actual: SCU.indexOf' (Pattern "") 2 "ab"
+--     , expected: Just 2
+--     }
+--   assertEqual
+--     { actual: SCU.indexOf' (Pattern "") 3 "ab"
+--     , expected: Nothing
+--     }
+--   assertEqual
+--     { actual: SCU.indexOf' (Pattern "bc") 0 "abcd"
+--     , expected: Just 1
+--     }
+--   assertEqual
+--     { actual: SCU.indexOf' (Pattern "bc") 1 "abcd"
+--     , expected: Just 1
+--     }
+--   assertEqual
+--     { actual: SCU.indexOf' (Pattern "bc") 2 "abcd"
+--     , expected: Nothing
+--     }
+--   assertEqual
+--     { actual: SCU.indexOf' (Pattern "cb") 0 "abcd"
+--     , expected: Nothing
+--     }
 
-  log "lastIndexOf"
-  assertEqual
-    { actual: SCU.lastIndexOf (Pattern "") ""
-    , expected: Just 0
-    }
-  assertEqual
-    { actual: SCU.lastIndexOf (Pattern "") "abcd"
-    , expected: Just 4
-    }
-  assertEqual
-    { actual: SCU.lastIndexOf (Pattern "bc") "abcd"
-    , expected: Just 1
-    }
-  assertEqual
-    { actual: SCU.lastIndexOf (Pattern "cb") "abcd"
-    , expected: Nothing
-    }
+--   log "lastIndexOf"
+--   assertEqual
+--     { actual: SCU.lastIndexOf (Pattern "") ""
+--     , expected: Just 0
+--     }
+--   assertEqual
+--     { actual: SCU.lastIndexOf (Pattern "") "abcd"
+--     , expected: Just 4
+--     }
+--   assertEqual
+--     { actual: SCU.lastIndexOf (Pattern "bc") "abcd"
+--     , expected: Just 1
+--     }
+--   assertEqual
+--     { actual: SCU.lastIndexOf (Pattern "cb") "abcd"
+--     , expected: Nothing
+--     }
 
-  log "lastIndexOf'"
-  assertEqual
-    { actual: SCU.lastIndexOf' (Pattern "") 0 ""
-    , expected: Just 0
-    }
-  assertEqual
-    { actual: SCU.lastIndexOf' (Pattern "") (-1) "ab"
-    , expected: Just 0
-    }
-  assertEqual
-    { actual: SCU.lastIndexOf' (Pattern "") 0 "ab"
-    , expected: Just 0
-    }
-  assertEqual
-    { actual: SCU.lastIndexOf' (Pattern "") 1 "ab"
-    , expected: Just 1
-    }
-  assertEqual
-    { actual: SCU.lastIndexOf' (Pattern "") 2 "ab"
-    , expected: Just 2
-    }
-  assertEqual
-    { actual: SCU.lastIndexOf' (Pattern "") 3 "ab"
-    , expected: Just 2
-    }
-  assertEqual
-    { actual: SCU.lastIndexOf' (Pattern "bc") 0 "abcd"
-    , expected: Nothing
-    }
-  assertEqual
-    { actual: SCU.lastIndexOf' (Pattern "bc") 1 "abcd"
-    , expected: Just 1
-    }
-  assertEqual
-    { actual: SCU.lastIndexOf' (Pattern "bc") 2 "abcd"
-    , expected: Just 1
-    }
-  assertEqual
-    { actual: SCU.lastIndexOf' (Pattern "cb") 0 "abcd"
-    , expected: Nothing
-    }
+--   log "lastIndexOf'"
+--   assertEqual
+--     { actual: SCU.lastIndexOf' (Pattern "") 0 ""
+--     , expected: Just 0
+--     }
+--   assertEqual
+--     { actual: SCU.lastIndexOf' (Pattern "") (-1) "ab"
+--     , expected: Just 0
+--     }
+--   assertEqual
+--     { actual: SCU.lastIndexOf' (Pattern "") 0 "ab"
+--     , expected: Just 0
+--     }
+--   assertEqual
+--     { actual: SCU.lastIndexOf' (Pattern "") 1 "ab"
+--     , expected: Just 1
+--     }
+--   assertEqual
+--     { actual: SCU.lastIndexOf' (Pattern "") 2 "ab"
+--     , expected: Just 2
+--     }
+--   assertEqual
+--     { actual: SCU.lastIndexOf' (Pattern "") 3 "ab"
+--     , expected: Just 2
+--     }
+--   assertEqual
+--     { actual: SCU.lastIndexOf' (Pattern "bc") 0 "abcd"
+--     , expected: Nothing
+--     }
+--   assertEqual
+--     { actual: SCU.lastIndexOf' (Pattern "bc") 1 "abcd"
+--     , expected: Just 1
+--     }
+--   assertEqual
+--     { actual: SCU.lastIndexOf' (Pattern "bc") 2 "abcd"
+--     , expected: Just 1
+--     }
+--   assertEqual
+--     { actual: SCU.lastIndexOf' (Pattern "cb") 0 "abcd"
+--     , expected: Nothing
+--     }
 
-  log "length"
-  assertEqual
-    { actual: SCU.length ""
-    , expected: 0
-    }
-  assertEqual
-    { actual: SCU.length "a"
-    , expected: 1
-    }
-  assertEqual
-    { actual: SCU.length "ab"
-    , expected: 2
-    }
+--   log "length"
+--   assertEqual
+--     { actual: SCU.length ""
+--     , expected: 0
+--     }
+--   assertEqual
+--     { actual: SCU.length "a"
+--     , expected: 1
+--     }
+--   assertEqual
+--     { actual: SCU.length "ab"
+--     , expected: 2
+--     }
 
-  log "take"
-  assertEqual
-    { actual: SCU.take 0 "ab"
-    , expected: ""
-    }
-  assertEqual
-    { actual: SCU.take 1 "ab"
-    , expected: "a"
-    }
-  assertEqual
-    { actual: SCU.take 2 "ab"
-    , expected: "ab"
-    }
-  assertEqual
-    { actual: SCU.take 3 "ab"
-    , expected: "ab"
-    }
-  assertEqual
-    { actual: SCU.take (-1) "ab"
-    , expected: ""
-    }
+--   log "take"
+--   assertEqual
+--     { actual: SCU.take 0 "ab"
+--     , expected: ""
+--     }
+--   assertEqual
+--     { actual: SCU.take 1 "ab"
+--     , expected: "a"
+--     }
+--   assertEqual
+--     { actual: SCU.take 2 "ab"
+--     , expected: "ab"
+--     }
+--   assertEqual
+--     { actual: SCU.take 3 "ab"
+--     , expected: "ab"
+--     }
+--   assertEqual
+--     { actual: SCU.take (-1) "ab"
+--     , expected: ""
+--     }
 
-  log "takeRight"
-  assertEqual
-    { actual: SCU.takeRight 0 "ab"
-    , expected: ""
-    }
-  assertEqual
-    { actual: SCU.takeRight 1 "ab"
-    , expected: "b"
-    }
-  assertEqual
-    { actual: SCU.takeRight 2 "ab"
-    , expected: "ab"
-    }
-  assertEqual
-    { actual: SCU.takeRight 3 "ab"
-    , expected: "ab"
-    }
-  assertEqual
-    { actual: SCU.takeRight (-1) "ab"
-    , expected: ""
-    }
+--   log "takeRight"
+--   assertEqual
+--     { actual: SCU.takeRight 0 "ab"
+--     , expected: ""
+--     }
+--   assertEqual
+--     { actual: SCU.takeRight 1 "ab"
+--     , expected: "b"
+--     }
+--   assertEqual
+--     { actual: SCU.takeRight 2 "ab"
+--     , expected: "ab"
+--     }
+--   assertEqual
+--     { actual: SCU.takeRight 3 "ab"
+--     , expected: "ab"
+--     }
+--   assertEqual
+--     { actual: SCU.takeRight (-1) "ab"
+--     , expected: ""
+--     }
 
-  log "drop"
-  assertEqual
-    { actual: SCU.drop 0 "ab"
-    , expected: "ab"
-    }
-  assertEqual
-    { actual: SCU.drop 1 "ab"
-    , expected: "b"
-    }
-  assertEqual
-    { actual: SCU.drop 2 "ab"
-    , expected: ""
-    }
-  assertEqual
-    { actual: SCU.drop 3 "ab"
-    , expected: ""
-    }
-  assertEqual
-    { actual: SCU.drop (-1) "ab"
-    , expected: "ab"
-    }
+--   log "drop"
+--   assertEqual
+--     { actual: SCU.drop 0 "ab"
+--     , expected: "ab"
+--     }
+--   assertEqual
+--     { actual: SCU.drop 1 "ab"
+--     , expected: "b"
+--     }
+--   assertEqual
+--     { actual: SCU.drop 2 "ab"
+--     , expected: ""
+--     }
+--   assertEqual
+--     { actual: SCU.drop 3 "ab"
+--     , expected: ""
+--     }
+--   assertEqual
+--     { actual: SCU.drop (-1) "ab"
+--     , expected: "ab"
+--     }
 
-  log "dropRight"
-  assertEqual
-    { actual: SCU.dropRight 0 "ab"
-    , expected: "ab"
-    }
-  assertEqual
-    { actual: SCU.dropRight 1 "ab"
-    , expected: "a"
-    }
-  assertEqual
-    { actual: SCU.dropRight 2 "ab"
-    , expected: ""
-    }
-  assertEqual
-    { actual: SCU.dropRight 3 "ab"
-    , expected: ""
-    }
-  assertEqual
-    { actual: SCU.dropRight (-1) "ab"
-    , expected: "ab"
-    }
+--   log "dropRight"
+--   assertEqual
+--     { actual: SCU.dropRight 0 "ab"
+--     , expected: "ab"
+--     }
+--   assertEqual
+--     { actual: SCU.dropRight 1 "ab"
+--     , expected: "a"
+--     }
+--   assertEqual
+--     { actual: SCU.dropRight 2 "ab"
+--     , expected: ""
+--     }
+--   assertEqual
+--     { actual: SCU.dropRight 3 "ab"
+--     , expected: ""
+--     }
+--   assertEqual
+--     { actual: SCU.dropRight (-1) "ab"
+--     , expected: "ab"
+--     }
 
-  log "countPrefix"
-  assertEqual
-    { actual: SCU.countPrefix (_ == 'a') ""
-    , expected: 0
-    }
-  assertEqual
-    { actual: SCU.countPrefix (_ == 'a') "ab"
-    , expected: 1
-    }
-  assertEqual
-    { actual: SCU.countPrefix (_ == 'a') "aaab"
-    , expected: 3
-    }
-  assertEqual
-    { actual: SCU.countPrefix (_ == 'a') "abaa"
-    , expected: 1
-    }
+--   log "countPrefix"
+--   assertEqual
+--     { actual: SCU.countPrefix (_ == 'a') ""
+--     , expected: 0
+--     }
+--   assertEqual
+--     { actual: SCU.countPrefix (_ == 'a') "ab"
+--     , expected: 1
+--     }
+--   assertEqual
+--     { actual: SCU.countPrefix (_ == 'a') "aaab"
+--     , expected: 3
+--     }
+--   assertEqual
+--     { actual: SCU.countPrefix (_ == 'a') "abaa"
+--     , expected: 1
+--     }
 
-  log "splitAt"
-  assertEqual
-    { actual: SCU.splitAt 1 ""
-    , expected: {before: "", after: ""}
-    }
-  assertEqual
-    { actual: SCU.splitAt 0 "a"
-    , expected: {before: "", after: "a"}
-    }
-  assertEqual
-    { actual: SCU.splitAt 1 "a"
-    , expected: {before: "a", after: ""}
-    }
-  assertEqual
-    { actual: SCU.splitAt 1 "ab"
-    , expected: {before: "a", after: "b"}
-    }
-  assertEqual
-    { actual: SCU.splitAt 3 "aabcc"
-    , expected: {before: "aab", after: "cc"}
-    }
-  assertEqual
-    { actual: SCU.splitAt (-1) "abc"
-    , expected: {before: "", after: "abc"}
-    }
-  assertEqual
-    { actual: SCU.splitAt 10 "Hi"
-    , expected: {before: "Hi", after: ""}
-    }
+--   log "splitAt"
+--   assertEqual
+--     { actual: SCU.splitAt 1 ""
+--     , expected: {before: "", after: ""}
+--     }
+--   assertEqual
+--     { actual: SCU.splitAt 0 "a"
+--     , expected: {before: "", after: "a"}
+--     }
+--   assertEqual
+--     { actual: SCU.splitAt 1 "a"
+--     , expected: {before: "a", after: ""}
+--     }
+--   assertEqual
+--     { actual: SCU.splitAt 1 "ab"
+--     , expected: {before: "a", after: "b"}
+--     }
+--   assertEqual
+--     { actual: SCU.splitAt 3 "aabcc"
+--     , expected: {before: "aab", after: "cc"}
+--     }
+--   assertEqual
+--     { actual: SCU.splitAt (-1) "abc"
+--     , expected: {before: "", after: "abc"}
+--     }
+--   assertEqual
+--     { actual: SCU.splitAt 10 "Hi"
+--     , expected: {before: "Hi", after: ""}
+--     }
 
-  log "toCharArray"
-  assertEqual
-    { actual: SCU.toCharArray ""
-    , expected: []
-    }
-  assertEqual
-    { actual: SCU.toCharArray "a"
-    , expected: ['a']
-    }
-  assertEqual
-    { actual: SCU.toCharArray "ab"
-    , expected: ['a', 'b']
-    }
+--   log "toCharArray"
+--   assertEqual
+--     { actual: SCU.toCharArray ""
+--     , expected: []
+--     }
+--   assertEqual
+--     { actual: SCU.toCharArray "a"
+--     , expected: ['a']
+--     }
+--   assertEqual
+--     { actual: SCU.toCharArray "ab"
+--     , expected: ['a', 'b']
+--     }
 
-  log "slice"
-  assertEqual
-    { actual: SCU.slice 0 0   "purescript"
-    , expected: ""
-    }
-  assertEqual
-    { actual: SCU.slice 0 1   "purescript"
-    , expected: "p"
-    }
-  assertEqual
-    { actual: SCU.slice 3 6   "purescript"
-    , expected: "esc"
-    }
-  assertEqual
-    { actual: SCU.slice 3 10  "purescript"
-    , expected: "escript"
-    }
-  assertEqual
-    { actual: SCU.slice 10 10 "purescript"
-    , expected: ""
-    }
-  assertEqual
-    { actual: SCU.slice (-4) (-1) "purescript"
-    , expected: "rip"
-    }
-  assertEqual
-    { actual: SCU.slice (-4) 3  "purescript"
-    , expected: ""
-    }
-  assertEqual
-    { actual: SCU.slice 1000 3  "purescript"
-    , expected: ""
-    }
-  assertEqual
-    { actual: SCU.slice 2 (-15) "purescript"
-    , expected: ""
-    }
-  assertEqual
-    { actual: SCU.slice (-15) 9 "purescript"
-    , expected: "purescrip"
-    }
-  assertEqual
-    { actual: SCU.slice 3 1000 "purescript"
-    , expected: "escript"
-    }
+--   log "slice"
+--   assertEqual
+--     { actual: SCU.slice 0 0   "purescript"
+--     , expected: ""
+--     }
+--   assertEqual
+--     { actual: SCU.slice 0 1   "purescript"
+--     , expected: "p"
+--     }
+--   assertEqual
+--     { actual: SCU.slice 3 6   "purescript"
+--     , expected: "esc"
+--     }
+--   assertEqual
+--     { actual: SCU.slice 3 10  "purescript"
+--     , expected: "escript"
+--     }
+--   assertEqual
+--     { actual: SCU.slice 10 10 "purescript"
+--     , expected: ""
+--     }
+--   assertEqual
+--     { actual: SCU.slice (-4) (-1) "purescript"
+--     , expected: "rip"
+--     }
+--   assertEqual
+--     { actual: SCU.slice (-4) 3  "purescript"
+--     , expected: ""
+--     }
+--   assertEqual
+--     { actual: SCU.slice 1000 3  "purescript"
+--     , expected: ""
+--     }
+--   assertEqual
+--     { actual: SCU.slice 2 (-15) "purescript"
+--     , expected: ""
+--     }
+--   assertEqual
+--     { actual: SCU.slice (-15) 9 "purescript"
+--     , expected: "purescrip"
+--     }
+--   assertEqual
+--     { actual: SCU.slice 3 1000 "purescript"
+--     , expected: "escript"
+--     }

--- a/test/Test/Data/String/CodeUnits.purs
+++ b/test/Test/Data/String/CodeUnits.purs
@@ -1,517 +1,516 @@
--- module Test.Data.String.CodeUnits (testStringCodeUnits) where
-module Test.Data.String.CodeUnits where
+module Test.Data.String.CodeUnits (testStringCodeUnits) where
 
--- import Prelude
+import Prelude
 
--- import Data.Enum (fromEnum)
--- import Data.Maybe (Maybe(..), isNothing)
--- import Data.String.CodeUnits as SCU
--- import Data.String.Pattern (Pattern(..))
--- import Effect (Effect)
--- import Effect.Console (log)
--- import Test.Assert (assert, assertEqual)
+import Data.Enum (fromEnum)
+import Data.Maybe (Maybe(..), isNothing)
+import Data.String.CodeUnits as SCU
+import Data.String.Pattern (Pattern(..))
+import Effect (Effect)
+import Effect.Console (log)
+import Test.Assert (assert, assertEqual)
 
--- testStringCodeUnits :: Effect Unit
--- testStringCodeUnits = do
---   log "stripPrefix"
---   assertEqual
---     { actual: SCU.stripPrefix (Pattern "abc") "abcde"
---     , expected: Just "de"
---     }
---   assertEqual
---     { actual: SCU.stripPrefix (Pattern "xyz") "abcde"
---     , expected: Nothing
---     }
---   assertEqual
---     { actual: SCU.stripPrefix (Pattern "abcd") "ab"
---     , expected: Nothing
---     }
---   assertEqual
---     { actual: SCU.stripPrefix (Pattern "abc") "abc"
---     , expected: Just ""
---     }
---   assertEqual
---     { actual: SCU.stripPrefix (Pattern "") "abc"
---     , expected: Just "abc"
---     }
---   assertEqual
---     { actual: SCU.stripPrefix (Pattern "") ""
---     , expected: Just ""
---     }
+testStringCodeUnits :: Effect Unit
+testStringCodeUnits = do
+  log "stripPrefix"
+  assertEqual
+    { actual: SCU.stripPrefix (Pattern "abc") "abcde"
+    , expected: Just "de"
+    }
+  assertEqual
+    { actual: SCU.stripPrefix (Pattern "xyz") "abcde"
+    , expected: Nothing
+    }
+  assertEqual
+    { actual: SCU.stripPrefix (Pattern "abcd") "ab"
+    , expected: Nothing
+    }
+  assertEqual
+    { actual: SCU.stripPrefix (Pattern "abc") "abc"
+    , expected: Just ""
+    }
+  assertEqual
+    { actual: SCU.stripPrefix (Pattern "") "abc"
+    , expected: Just "abc"
+    }
+  assertEqual
+    { actual: SCU.stripPrefix (Pattern "") ""
+    , expected: Just ""
+    }
 
---   log "stripSuffix"
---   assertEqual
---     { actual: SCU.stripSuffix (Pattern "cde") "abcde"
---     , expected: Just "ab"
---     }
---   assertEqual
---     { actual: SCU.stripSuffix (Pattern "xyz") "abcde"
---     , expected: Nothing
---     }
---   assertEqual
---     { actual: SCU.stripSuffix (Pattern "abcd") "cd"
---     , expected: Nothing
---     }
---   assertEqual
---     { actual: SCU.stripSuffix (Pattern "abc") "abc"
---     , expected: Just ""
---     }
---   assertEqual
---     { actual: SCU.stripSuffix (Pattern "") "abc"
---     , expected: Just "abc"
---     }
---   assertEqual
---     { actual: SCU.stripSuffix (Pattern "") ""
---     , expected: Just ""
---     }
+  log "stripSuffix"
+  assertEqual
+    { actual: SCU.stripSuffix (Pattern "cde") "abcde"
+    , expected: Just "ab"
+    }
+  assertEqual
+    { actual: SCU.stripSuffix (Pattern "xyz") "abcde"
+    , expected: Nothing
+    }
+  assertEqual
+    { actual: SCU.stripSuffix (Pattern "abcd") "cd"
+    , expected: Nothing
+    }
+  assertEqual
+    { actual: SCU.stripSuffix (Pattern "abc") "abc"
+    , expected: Just ""
+    }
+  assertEqual
+    { actual: SCU.stripSuffix (Pattern "") "abc"
+    , expected: Just "abc"
+    }
+  assertEqual
+    { actual: SCU.stripSuffix (Pattern "") ""
+    , expected: Just ""
+    }
 
---   log "charAt"
---   assertEqual
---     { actual: SCU.charAt 0 ""
---     , expected: Nothing
---     }
---   assertEqual
---     { actual: SCU.charAt 0 "a"
---     , expected: Just 'a'
---     }
---   assertEqual
---     { actual: SCU.charAt 1 "a"
---     , expected: Nothing
---     }
---   assertEqual
---     { actual: SCU.charAt 0 "ab"
---     , expected: Just 'a'
---     }
---   assertEqual
---     { actual: SCU.charAt 1 "ab"
---     , expected: Just 'b'
---     }
---   assertEqual
---     { actual: SCU.charAt 2 "ab"
---     , expected: Nothing
---     }
+  log "charAt"
+  assertEqual
+    { actual: SCU.charAt 0 ""
+    , expected: Nothing
+    }
+  assertEqual
+    { actual: SCU.charAt 0 "a"
+    , expected: Just 'a'
+    }
+  assertEqual
+    { actual: SCU.charAt 1 "a"
+    , expected: Nothing
+    }
+  assertEqual
+    { actual: SCU.charAt 0 "ab"
+    , expected: Just 'a'
+    }
+  assertEqual
+    { actual: SCU.charAt 1 "ab"
+    , expected: Just 'b'
+    }
+  assertEqual
+    { actual: SCU.charAt 2 "ab"
+    , expected: Nothing
+    }
 
---   log "singleton"
---   assertEqual
---     { actual: SCU.singleton 'a'
---     , expected: "a"
---     }
+  log "singleton"
+  assertEqual
+    { actual: SCU.singleton 'a'
+    , expected: "a"
+    }
 
---   log "charCodeAt"
---   assertEqual
---     { actual: (fromEnum <$> SCU.charAt 0 "")
---     , expected: Nothing
---     }
---   assertEqual
---     { actual: (fromEnum <$> SCU.charAt 0 "a")
---     , expected: Just 97
---     }
---   assertEqual
---     { actual: (fromEnum <$> SCU.charAt 1 "a")
---     , expected: Nothing
---     }
---   assertEqual
---     { actual: (fromEnum <$> SCU.charAt 0 "ab")
---     , expected: Just 97
---     }
---   assertEqual
---     { actual: (fromEnum <$> SCU.charAt 1 "ab")
---     , expected: Just 98
---     }
---   assertEqual
---     { actual: (fromEnum <$> SCU.charAt 2 "ab")
---     , expected: Nothing
---     }
+  log "charCodeAt"
+  assertEqual
+    { actual: (fromEnum <$> SCU.charAt 0 "")
+    , expected: Nothing
+    }
+  assertEqual
+    { actual: (fromEnum <$> SCU.charAt 0 "a")
+    , expected: Just 97
+    }
+  assertEqual
+    { actual: (fromEnum <$> SCU.charAt 1 "a")
+    , expected: Nothing
+    }
+  assertEqual
+    { actual: (fromEnum <$> SCU.charAt 0 "ab")
+    , expected: Just 97
+    }
+  assertEqual
+    { actual: (fromEnum <$> SCU.charAt 1 "ab")
+    , expected: Just 98
+    }
+  assertEqual
+    { actual: (fromEnum <$> SCU.charAt 2 "ab")
+    , expected: Nothing
+    }
 
---   log "toChar"
---   assertEqual
---     { actual: SCU.toChar ""
---     , expected: Nothing
---     }
---   assertEqual
---     { actual: SCU.toChar "a"
---     , expected: Just 'a'
---     }
---   assertEqual
---     { actual: SCU.toChar "ab"
---     , expected: Nothing
---     }
+  log "toChar"
+  assertEqual
+    { actual: SCU.toChar ""
+    , expected: Nothing
+    }
+  assertEqual
+    { actual: SCU.toChar "a"
+    , expected: Just 'a'
+    }
+  assertEqual
+    { actual: SCU.toChar "ab"
+    , expected: Nothing
+    }
 
---   log "uncons"
---   assert $ isNothing (SCU.uncons "")
---   assertEqual
---     { actual: SCU.uncons "a"
---     , expected: Just { head: 'a', tail: "" }
---     }
---   assertEqual
---     { actual: SCU.uncons "ab"
---     , expected: Just { head: 'a', tail: "b" }
---     }
+  log "uncons"
+  assert $ isNothing (SCU.uncons "")
+  assertEqual
+    { actual: SCU.uncons "a"
+    , expected: Just { head: 'a', tail: "" }
+    }
+  assertEqual
+    { actual: SCU.uncons "ab"
+    , expected: Just { head: 'a', tail: "b" }
+    }
 
---   log "takeWhile"
---   assertEqual
---     { actual: SCU.takeWhile (\c -> true) "abc"
---     , expected: "abc"
---     }
---   assertEqual
---     { actual: SCU.takeWhile (\c -> false) "abc"
---     , expected: ""
---     }
---   assertEqual
---     { actual: SCU.takeWhile (\c -> c /= 'b') "aabbcc"
---     , expected: "aa"
---     }
+  log "takeWhile"
+  assertEqual
+    { actual: SCU.takeWhile (\c -> true) "abc"
+    , expected: "abc"
+    }
+  assertEqual
+    { actual: SCU.takeWhile (\c -> false) "abc"
+    , expected: ""
+    }
+  assertEqual
+    { actual: SCU.takeWhile (\c -> c /= 'b') "aabbcc"
+    , expected: "aa"
+    }
 
---   log "dropWhile"
---   assertEqual
---     { actual: SCU.dropWhile (\c -> true) "abc"
---     , expected: ""
---     }
---   assertEqual
---     { actual: SCU.dropWhile (\c -> false) "abc"
---     , expected: "abc"
---     }
---   assertEqual
---     { actual: SCU.dropWhile (\c -> c /= 'b') "aabbcc"
---     , expected: "bbcc"
---     }
+  log "dropWhile"
+  assertEqual
+    { actual: SCU.dropWhile (\c -> true) "abc"
+    , expected: ""
+    }
+  assertEqual
+    { actual: SCU.dropWhile (\c -> false) "abc"
+    , expected: "abc"
+    }
+  assertEqual
+    { actual: SCU.dropWhile (\c -> c /= 'b') "aabbcc"
+    , expected: "bbcc"
+    }
 
---   log "fromCharArray"
---   assertEqual
---     { actual: SCU.fromCharArray []
---       , expected: ""
---       }
---   assertEqual
---     { actual: SCU.fromCharArray ['a', 'b']
---     , expected: "ab"
---     }
+  log "fromCharArray"
+  assertEqual
+    { actual: SCU.fromCharArray []
+      , expected: ""
+      }
+  assertEqual
+    { actual: SCU.fromCharArray ['a', 'b']
+    , expected: "ab"
+    }
 
---   log "indexOf"
---   assertEqual
---     { actual: SCU.indexOf (Pattern "") ""
---     , expected: Just 0
---     }
---   assertEqual
---     { actual: SCU.indexOf (Pattern "") "abcd"
---     , expected: Just 0
---     }
---   assertEqual
---     { actual: SCU.indexOf (Pattern "bc") "abcd"
---     , expected: Just 1
---     }
---   assertEqual
---     { actual: SCU.indexOf (Pattern "cb") "abcd"
---     , expected: Nothing
---     }
+  log "indexOf"
+  assertEqual
+    { actual: SCU.indexOf (Pattern "") ""
+    , expected: Just 0
+    }
+  assertEqual
+    { actual: SCU.indexOf (Pattern "") "abcd"
+    , expected: Just 0
+    }
+  assertEqual
+    { actual: SCU.indexOf (Pattern "bc") "abcd"
+    , expected: Just 1
+    }
+  assertEqual
+    { actual: SCU.indexOf (Pattern "cb") "abcd"
+    , expected: Nothing
+    }
 
---   log "indexOf'"
---   assertEqual
---     { actual: SCU.indexOf' (Pattern "") 0 ""
---     , expected: Just 0
---     }
---   assertEqual
---     { actual: SCU.indexOf' (Pattern "") (-1) "ab"
---     , expected: Nothing
---     }
---   assertEqual
---     { actual: SCU.indexOf' (Pattern "") 0 "ab"
---     , expected: Just 0
---     }
---   assertEqual
---     { actual: SCU.indexOf' (Pattern "") 1 "ab"
---     , expected: Just 1
---     }
---   assertEqual
---     { actual: SCU.indexOf' (Pattern "") 2 "ab"
---     , expected: Just 2
---     }
---   assertEqual
---     { actual: SCU.indexOf' (Pattern "") 3 "ab"
---     , expected: Nothing
---     }
---   assertEqual
---     { actual: SCU.indexOf' (Pattern "bc") 0 "abcd"
---     , expected: Just 1
---     }
---   assertEqual
---     { actual: SCU.indexOf' (Pattern "bc") 1 "abcd"
---     , expected: Just 1
---     }
---   assertEqual
---     { actual: SCU.indexOf' (Pattern "bc") 2 "abcd"
---     , expected: Nothing
---     }
---   assertEqual
---     { actual: SCU.indexOf' (Pattern "cb") 0 "abcd"
---     , expected: Nothing
---     }
+  log "indexOf'"
+  assertEqual
+    { actual: SCU.indexOf' (Pattern "") 0 ""
+    , expected: Just 0
+    }
+  assertEqual
+    { actual: SCU.indexOf' (Pattern "") (-1) "ab"
+    , expected: Nothing
+    }
+  assertEqual
+    { actual: SCU.indexOf' (Pattern "") 0 "ab"
+    , expected: Just 0
+    }
+  assertEqual
+    { actual: SCU.indexOf' (Pattern "") 1 "ab"
+    , expected: Just 1
+    }
+  assertEqual
+    { actual: SCU.indexOf' (Pattern "") 2 "ab"
+    , expected: Just 2
+    }
+  assertEqual
+    { actual: SCU.indexOf' (Pattern "") 3 "ab"
+    , expected: Nothing
+    }
+  assertEqual
+    { actual: SCU.indexOf' (Pattern "bc") 0 "abcd"
+    , expected: Just 1
+    }
+  assertEqual
+    { actual: SCU.indexOf' (Pattern "bc") 1 "abcd"
+    , expected: Just 1
+    }
+  assertEqual
+    { actual: SCU.indexOf' (Pattern "bc") 2 "abcd"
+    , expected: Nothing
+    }
+  assertEqual
+    { actual: SCU.indexOf' (Pattern "cb") 0 "abcd"
+    , expected: Nothing
+    }
 
---   log "lastIndexOf"
---   assertEqual
---     { actual: SCU.lastIndexOf (Pattern "") ""
---     , expected: Just 0
---     }
---   assertEqual
---     { actual: SCU.lastIndexOf (Pattern "") "abcd"
---     , expected: Just 4
---     }
---   assertEqual
---     { actual: SCU.lastIndexOf (Pattern "bc") "abcd"
---     , expected: Just 1
---     }
---   assertEqual
---     { actual: SCU.lastIndexOf (Pattern "cb") "abcd"
---     , expected: Nothing
---     }
+  log "lastIndexOf"
+  assertEqual
+    { actual: SCU.lastIndexOf (Pattern "") ""
+    , expected: Just 0
+    }
+  assertEqual
+    { actual: SCU.lastIndexOf (Pattern "") "abcd"
+    , expected: Just 4
+    }
+  assertEqual
+    { actual: SCU.lastIndexOf (Pattern "bc") "abcd"
+    , expected: Just 1
+    }
+  assertEqual
+    { actual: SCU.lastIndexOf (Pattern "cb") "abcd"
+    , expected: Nothing
+    }
 
---   log "lastIndexOf'"
---   assertEqual
---     { actual: SCU.lastIndexOf' (Pattern "") 0 ""
---     , expected: Just 0
---     }
---   assertEqual
---     { actual: SCU.lastIndexOf' (Pattern "") (-1) "ab"
---     , expected: Just 0
---     }
---   assertEqual
---     { actual: SCU.lastIndexOf' (Pattern "") 0 "ab"
---     , expected: Just 0
---     }
---   assertEqual
---     { actual: SCU.lastIndexOf' (Pattern "") 1 "ab"
---     , expected: Just 1
---     }
---   assertEqual
---     { actual: SCU.lastIndexOf' (Pattern "") 2 "ab"
---     , expected: Just 2
---     }
---   assertEqual
---     { actual: SCU.lastIndexOf' (Pattern "") 3 "ab"
---     , expected: Just 2
---     }
---   assertEqual
---     { actual: SCU.lastIndexOf' (Pattern "bc") 0 "abcd"
---     , expected: Nothing
---     }
---   assertEqual
---     { actual: SCU.lastIndexOf' (Pattern "bc") 1 "abcd"
---     , expected: Just 1
---     }
---   assertEqual
---     { actual: SCU.lastIndexOf' (Pattern "bc") 2 "abcd"
---     , expected: Just 1
---     }
---   assertEqual
---     { actual: SCU.lastIndexOf' (Pattern "cb") 0 "abcd"
---     , expected: Nothing
---     }
+  log "lastIndexOf'"
+  assertEqual
+    { actual: SCU.lastIndexOf' (Pattern "") 0 ""
+    , expected: Just 0
+    }
+  assertEqual
+    { actual: SCU.lastIndexOf' (Pattern "") (-1) "ab"
+    , expected: Just 0
+    }
+  assertEqual
+    { actual: SCU.lastIndexOf' (Pattern "") 0 "ab"
+    , expected: Just 0
+    }
+  assertEqual
+    { actual: SCU.lastIndexOf' (Pattern "") 1 "ab"
+    , expected: Just 1
+    }
+  assertEqual
+    { actual: SCU.lastIndexOf' (Pattern "") 2 "ab"
+    , expected: Just 2
+    }
+  assertEqual
+    { actual: SCU.lastIndexOf' (Pattern "") 3 "ab"
+    , expected: Just 2
+    }
+  assertEqual
+    { actual: SCU.lastIndexOf' (Pattern "bc") 0 "abcd"
+    , expected: Nothing
+    }
+  assertEqual
+    { actual: SCU.lastIndexOf' (Pattern "bc") 1 "abcd"
+    , expected: Just 1
+    }
+  assertEqual
+    { actual: SCU.lastIndexOf' (Pattern "bc") 2 "abcd"
+    , expected: Just 1
+    }
+  assertEqual
+    { actual: SCU.lastIndexOf' (Pattern "cb") 0 "abcd"
+    , expected: Nothing
+    }
 
---   log "length"
---   assertEqual
---     { actual: SCU.length ""
---     , expected: 0
---     }
---   assertEqual
---     { actual: SCU.length "a"
---     , expected: 1
---     }
---   assertEqual
---     { actual: SCU.length "ab"
---     , expected: 2
---     }
+  log "length"
+  assertEqual
+    { actual: SCU.length ""
+    , expected: 0
+    }
+  assertEqual
+    { actual: SCU.length "a"
+    , expected: 1
+    }
+  assertEqual
+    { actual: SCU.length "ab"
+    , expected: 2
+    }
 
---   log "take"
---   assertEqual
---     { actual: SCU.take 0 "ab"
---     , expected: ""
---     }
---   assertEqual
---     { actual: SCU.take 1 "ab"
---     , expected: "a"
---     }
---   assertEqual
---     { actual: SCU.take 2 "ab"
---     , expected: "ab"
---     }
---   assertEqual
---     { actual: SCU.take 3 "ab"
---     , expected: "ab"
---     }
---   assertEqual
---     { actual: SCU.take (-1) "ab"
---     , expected: ""
---     }
+  log "take"
+  assertEqual
+    { actual: SCU.take 0 "ab"
+    , expected: ""
+    }
+  assertEqual
+    { actual: SCU.take 1 "ab"
+    , expected: "a"
+    }
+  assertEqual
+    { actual: SCU.take 2 "ab"
+    , expected: "ab"
+    }
+  assertEqual
+    { actual: SCU.take 3 "ab"
+    , expected: "ab"
+    }
+  assertEqual
+    { actual: SCU.take (-1) "ab"
+    , expected: ""
+    }
 
---   log "takeRight"
---   assertEqual
---     { actual: SCU.takeRight 0 "ab"
---     , expected: ""
---     }
---   assertEqual
---     { actual: SCU.takeRight 1 "ab"
---     , expected: "b"
---     }
---   assertEqual
---     { actual: SCU.takeRight 2 "ab"
---     , expected: "ab"
---     }
---   assertEqual
---     { actual: SCU.takeRight 3 "ab"
---     , expected: "ab"
---     }
---   assertEqual
---     { actual: SCU.takeRight (-1) "ab"
---     , expected: ""
---     }
+  log "takeRight"
+  assertEqual
+    { actual: SCU.takeRight 0 "ab"
+    , expected: ""
+    }
+  assertEqual
+    { actual: SCU.takeRight 1 "ab"
+    , expected: "b"
+    }
+  assertEqual
+    { actual: SCU.takeRight 2 "ab"
+    , expected: "ab"
+    }
+  assertEqual
+    { actual: SCU.takeRight 3 "ab"
+    , expected: "ab"
+    }
+  assertEqual
+    { actual: SCU.takeRight (-1) "ab"
+    , expected: ""
+    }
 
---   log "drop"
---   assertEqual
---     { actual: SCU.drop 0 "ab"
---     , expected: "ab"
---     }
---   assertEqual
---     { actual: SCU.drop 1 "ab"
---     , expected: "b"
---     }
---   assertEqual
---     { actual: SCU.drop 2 "ab"
---     , expected: ""
---     }
---   assertEqual
---     { actual: SCU.drop 3 "ab"
---     , expected: ""
---     }
---   assertEqual
---     { actual: SCU.drop (-1) "ab"
---     , expected: "ab"
---     }
+  log "drop"
+  assertEqual
+    { actual: SCU.drop 0 "ab"
+    , expected: "ab"
+    }
+  assertEqual
+    { actual: SCU.drop 1 "ab"
+    , expected: "b"
+    }
+  assertEqual
+    { actual: SCU.drop 2 "ab"
+    , expected: ""
+    }
+  assertEqual
+    { actual: SCU.drop 3 "ab"
+    , expected: ""
+    }
+  assertEqual
+    { actual: SCU.drop (-1) "ab"
+    , expected: "ab"
+    }
 
---   log "dropRight"
---   assertEqual
---     { actual: SCU.dropRight 0 "ab"
---     , expected: "ab"
---     }
---   assertEqual
---     { actual: SCU.dropRight 1 "ab"
---     , expected: "a"
---     }
---   assertEqual
---     { actual: SCU.dropRight 2 "ab"
---     , expected: ""
---     }
---   assertEqual
---     { actual: SCU.dropRight 3 "ab"
---     , expected: ""
---     }
---   assertEqual
---     { actual: SCU.dropRight (-1) "ab"
---     , expected: "ab"
---     }
+  log "dropRight"
+  assertEqual
+    { actual: SCU.dropRight 0 "ab"
+    , expected: "ab"
+    }
+  assertEqual
+    { actual: SCU.dropRight 1 "ab"
+    , expected: "a"
+    }
+  assertEqual
+    { actual: SCU.dropRight 2 "ab"
+    , expected: ""
+    }
+  assertEqual
+    { actual: SCU.dropRight 3 "ab"
+    , expected: ""
+    }
+  assertEqual
+    { actual: SCU.dropRight (-1) "ab"
+    , expected: "ab"
+    }
 
---   log "countPrefix"
---   assertEqual
---     { actual: SCU.countPrefix (_ == 'a') ""
---     , expected: 0
---     }
---   assertEqual
---     { actual: SCU.countPrefix (_ == 'a') "ab"
---     , expected: 1
---     }
---   assertEqual
---     { actual: SCU.countPrefix (_ == 'a') "aaab"
---     , expected: 3
---     }
---   assertEqual
---     { actual: SCU.countPrefix (_ == 'a') "abaa"
---     , expected: 1
---     }
+  log "countPrefix"
+  assertEqual
+    { actual: SCU.countPrefix (_ == 'a') ""
+    , expected: 0
+    }
+  assertEqual
+    { actual: SCU.countPrefix (_ == 'a') "ab"
+    , expected: 1
+    }
+  assertEqual
+    { actual: SCU.countPrefix (_ == 'a') "aaab"
+    , expected: 3
+    }
+  assertEqual
+    { actual: SCU.countPrefix (_ == 'a') "abaa"
+    , expected: 1
+    }
 
---   log "splitAt"
---   assertEqual
---     { actual: SCU.splitAt 1 ""
---     , expected: {before: "", after: ""}
---     }
---   assertEqual
---     { actual: SCU.splitAt 0 "a"
---     , expected: {before: "", after: "a"}
---     }
---   assertEqual
---     { actual: SCU.splitAt 1 "a"
---     , expected: {before: "a", after: ""}
---     }
---   assertEqual
---     { actual: SCU.splitAt 1 "ab"
---     , expected: {before: "a", after: "b"}
---     }
---   assertEqual
---     { actual: SCU.splitAt 3 "aabcc"
---     , expected: {before: "aab", after: "cc"}
---     }
---   assertEqual
---     { actual: SCU.splitAt (-1) "abc"
---     , expected: {before: "", after: "abc"}
---     }
---   assertEqual
---     { actual: SCU.splitAt 10 "Hi"
---     , expected: {before: "Hi", after: ""}
---     }
+  log "splitAt"
+  assertEqual
+    { actual: SCU.splitAt 1 ""
+    , expected: {before: "", after: ""}
+    }
+  assertEqual
+    { actual: SCU.splitAt 0 "a"
+    , expected: {before: "", after: "a"}
+    }
+  assertEqual
+    { actual: SCU.splitAt 1 "a"
+    , expected: {before: "a", after: ""}
+    }
+  assertEqual
+    { actual: SCU.splitAt 1 "ab"
+    , expected: {before: "a", after: "b"}
+    }
+  assertEqual
+    { actual: SCU.splitAt 3 "aabcc"
+    , expected: {before: "aab", after: "cc"}
+    }
+  assertEqual
+    { actual: SCU.splitAt (-1) "abc"
+    , expected: {before: "", after: "abc"}
+    }
+  assertEqual
+    { actual: SCU.splitAt 10 "Hi"
+    , expected: {before: "Hi", after: ""}
+    }
 
---   log "toCharArray"
---   assertEqual
---     { actual: SCU.toCharArray ""
---     , expected: []
---     }
---   assertEqual
---     { actual: SCU.toCharArray "a"
---     , expected: ['a']
---     }
---   assertEqual
---     { actual: SCU.toCharArray "ab"
---     , expected: ['a', 'b']
---     }
+  log "toCharArray"
+  assertEqual
+    { actual: SCU.toCharArray ""
+    , expected: []
+    }
+  assertEqual
+    { actual: SCU.toCharArray "a"
+    , expected: ['a']
+    }
+  assertEqual
+    { actual: SCU.toCharArray "ab"
+    , expected: ['a', 'b']
+    }
 
---   log "slice"
---   assertEqual
---     { actual: SCU.slice 0 0   "purescript"
---     , expected: ""
---     }
---   assertEqual
---     { actual: SCU.slice 0 1   "purescript"
---     , expected: "p"
---     }
---   assertEqual
---     { actual: SCU.slice 3 6   "purescript"
---     , expected: "esc"
---     }
---   assertEqual
---     { actual: SCU.slice 3 10  "purescript"
---     , expected: "escript"
---     }
---   assertEqual
---     { actual: SCU.slice 10 10 "purescript"
---     , expected: ""
---     }
---   assertEqual
---     { actual: SCU.slice (-4) (-1) "purescript"
---     , expected: "rip"
---     }
---   assertEqual
---     { actual: SCU.slice (-4) 3  "purescript"
---     , expected: ""
---     }
---   assertEqual
---     { actual: SCU.slice 1000 3  "purescript"
---     , expected: ""
---     }
---   assertEqual
---     { actual: SCU.slice 2 (-15) "purescript"
---     , expected: ""
---     }
---   assertEqual
---     { actual: SCU.slice (-15) 9 "purescript"
---     , expected: "purescrip"
---     }
---   assertEqual
---     { actual: SCU.slice 3 1000 "purescript"
---     , expected: "escript"
---     }
+  log "slice"
+  assertEqual
+    { actual: SCU.slice 0 0   "purescript"
+    , expected: ""
+    }
+  assertEqual
+    { actual: SCU.slice 0 1   "purescript"
+    , expected: "p"
+    }
+  assertEqual
+    { actual: SCU.slice 3 6   "purescript"
+    , expected: "esc"
+    }
+  assertEqual
+    { actual: SCU.slice 3 10  "purescript"
+    , expected: "escript"
+    }
+  assertEqual
+    { actual: SCU.slice 10 10 "purescript"
+    , expected: ""
+    }
+  assertEqual
+    { actual: SCU.slice (-4) (-1) "purescript"
+    , expected: "rip"
+    }
+  assertEqual
+    { actual: SCU.slice (-4) 3  "purescript"
+    , expected: ""
+    }
+  assertEqual
+    { actual: SCU.slice 1000 3  "purescript"
+    , expected: ""
+    }
+  assertEqual
+    { actual: SCU.slice 2 (-15) "purescript"
+    , expected: ""
+    }
+  assertEqual
+    { actual: SCU.slice (-15) 9 "purescript"
+    , expected: "purescrip"
+    }
+  assertEqual
+    { actual: SCU.slice 3 1000 "purescript"
+    , expected: "escript"
+    }

--- a/test/Test/Data/String/NonEmpty.purs
+++ b/test/Test/Data/String/NonEmpty.purs
@@ -1,220 +1,221 @@
-module Test.Data.String.NonEmpty (testNonEmptyString) where
+-- module Test.Data.String.NonEmpty (testNonEmptyString) where
+module Test.Data.String.NonEmpty where
 
-import Prelude
+-- import Prelude
 
-import Data.Array.NonEmpty as NEA
-import Data.Maybe (Maybe(..), fromJust)
-import Data.String.NonEmpty (Pattern(..), nes)
-import Data.String.NonEmpty as NES
-import Effect (Effect)
-import Effect.Console (log)
-import Partial.Unsafe (unsafePartial)
-import Test.Assert (assert, assertEqual)
-import Type.Proxy (Proxy(..))
+-- import Data.Array.NonEmpty as NEA
+-- import Data.Maybe (Maybe(..), fromJust)
+-- import Data.String.NonEmpty (Pattern(..), nes)
+-- import Data.String.NonEmpty as NES
+-- import Effect (Effect)
+-- import Effect.Console (log)
+-- import Partial.Unsafe (unsafePartial)
+-- import Test.Assert (assert, assertEqual)
+-- import Type.Proxy (Proxy(..))
 
-testNonEmptyString :: Effect Unit
-testNonEmptyString = do
+-- testNonEmptyString :: Effect Unit
+-- testNonEmptyString = do
 
-  log "fromString"
-  assertEqual
-    { actual: NES.fromString ""
-    , expected: Nothing
-    }
-  assertEqual
-    { actual: NES.fromString "hello"
-    , expected: Just (nes (Proxy :: Proxy "hello"))
-    }
+--   log "fromString"
+--   assertEqual
+--     { actual: NES.fromString ""
+--     , expected: Nothing
+--     }
+--   assertEqual
+--     { actual: NES.fromString "hello"
+--     , expected: Just (nes (Proxy :: Proxy "hello"))
+--     }
 
-  log "toString"
-  assertEqual
-    { actual: (NES.toString <$> NES.fromString "hello")
-    , expected: Just "hello"
-    }
+--   log "toString"
+--   assertEqual
+--     { actual: (NES.toString <$> NES.fromString "hello")
+--     , expected: Just "hello"
+--     }
 
-  log "appendString"
-  assertEqual
-    { actual: NES.appendString (nes (Proxy :: Proxy "Hello")) " world"
-    , expected: nes (Proxy :: Proxy "Hello world")
-    }
-  assertEqual
-    { actual: NES.appendString (nes (Proxy :: Proxy "Hello")) ""
-    , expected: nes (Proxy :: Proxy "Hello")
-    }
+--   log "appendString"
+--   assertEqual
+--     { actual: NES.appendString (nes (Proxy :: Proxy "Hello")) " world"
+--     , expected: nes (Proxy :: Proxy "Hello world")
+--     }
+--   assertEqual
+--     { actual: NES.appendString (nes (Proxy :: Proxy "Hello")) ""
+--     , expected: nes (Proxy :: Proxy "Hello")
+--     }
 
-  log "prependString"
-  assertEqual
-    { actual: NES.prependString "be" (nes (Proxy :: Proxy "fore"))
-    , expected: nes (Proxy :: Proxy "before")
-    }
-  assertEqual
-    { actual: NES.prependString "" (nes (Proxy :: Proxy "fore"))
-    , expected: nes (Proxy :: Proxy "fore")
-    }
+--   log "prependString"
+--   assertEqual
+--     { actual: NES.prependString "be" (nes (Proxy :: Proxy "fore"))
+--     , expected: nes (Proxy :: Proxy "before")
+--     }
+--   assertEqual
+--     { actual: NES.prependString "" (nes (Proxy :: Proxy "fore"))
+--     , expected: nes (Proxy :: Proxy "fore")
+--     }
 
-  log "contains"
-  assert $ NES.contains (Pattern "") (nes (Proxy :: Proxy "abcd"))
-  assert $ NES.contains (Pattern "bc") (nes (Proxy :: Proxy "abcd"))
-  assert $ not NES.contains (Pattern "cb") (nes (Proxy :: Proxy "abcd"))
-  assert $ NES.contains (Pattern "needle") (nes (Proxy :: Proxy "haystack with needle"))
-  assert $ not NES.contains (Pattern "needle") (nes (Proxy :: Proxy "haystack"))
+--   log "contains"
+--   assert $ NES.contains (Pattern "") (nes (Proxy :: Proxy "abcd"))
+--   assert $ NES.contains (Pattern "bc") (nes (Proxy :: Proxy "abcd"))
+--   assert $ not NES.contains (Pattern "cb") (nes (Proxy :: Proxy "abcd"))
+--   assert $ NES.contains (Pattern "needle") (nes (Proxy :: Proxy "haystack with needle"))
+--   assert $ not NES.contains (Pattern "needle") (nes (Proxy :: Proxy "haystack"))
 
-  log "localeCompare"
-  assertEqual
-    { actual: NES.localeCompare (nes (Proxy :: Proxy "a")) (nes (Proxy :: Proxy "a"))
-    , expected: EQ
-    }
-  assertEqual
-    { actual: NES.localeCompare (nes (Proxy :: Proxy "a")) (nes (Proxy :: Proxy "b"))
-    , expected: LT
-    }
-  assertEqual
-    { actual: NES.localeCompare (nes (Proxy :: Proxy "b")) (nes (Proxy :: Proxy "a"))
-    , expected: GT
-    }
+--   log "localeCompare"
+--   assertEqual
+--     { actual: NES.localeCompare (nes (Proxy :: Proxy "a")) (nes (Proxy :: Proxy "a"))
+--     , expected: EQ
+--     }
+--   assertEqual
+--     { actual: NES.localeCompare (nes (Proxy :: Proxy "a")) (nes (Proxy :: Proxy "b"))
+--     , expected: LT
+--     }
+--   assertEqual
+--     { actual: NES.localeCompare (nes (Proxy :: Proxy "b")) (nes (Proxy :: Proxy "a"))
+--     , expected: GT
+--     }
 
-  log "replace"
-  assertEqual
-    { actual: NES.replace (Pattern "b") (NES.NonEmptyReplacement (nes (Proxy :: Proxy "!"))) (nes (Proxy :: Proxy "abc"))
-    , expected: nes (Proxy :: Proxy "a!c")
-    }
-  assertEqual
-    { actual: NES.replace (Pattern "b") (NES.NonEmptyReplacement (nes (Proxy :: Proxy "!"))) (nes (Proxy :: Proxy "abbc"))
-    , expected: nes (Proxy :: Proxy "a!bc")
-    }
-  assertEqual
-    { actual: NES.replace (Pattern "d") (NES.NonEmptyReplacement (nes (Proxy :: Proxy "!"))) (nes (Proxy :: Proxy "abc"))
-    , expected: nes (Proxy :: Proxy "abc")
-    }
+--   log "replace"
+--   assertEqual
+--     { actual: NES.replace (Pattern "b") (NES.NonEmptyReplacement (nes (Proxy :: Proxy "!"))) (nes (Proxy :: Proxy "abc"))
+--     , expected: nes (Proxy :: Proxy "a!c")
+--     }
+--   assertEqual
+--     { actual: NES.replace (Pattern "b") (NES.NonEmptyReplacement (nes (Proxy :: Proxy "!"))) (nes (Proxy :: Proxy "abbc"))
+--     , expected: nes (Proxy :: Proxy "a!bc")
+--     }
+--   assertEqual
+--     { actual: NES.replace (Pattern "d") (NES.NonEmptyReplacement (nes (Proxy :: Proxy "!"))) (nes (Proxy :: Proxy "abc"))
+--     , expected: nes (Proxy :: Proxy "abc")
+--     }
 
-  log "replaceAll"
-  assertEqual
-    { actual: NES.replaceAll (Pattern "[b]") (NES.NonEmptyReplacement (nes (Proxy :: Proxy "!"))) (nes (Proxy :: Proxy "a[b]c"))
-    , expected: nes (Proxy :: Proxy "a!c")
-    }
-  assertEqual
-    { actual: NES.replaceAll (Pattern "[b]") (NES.NonEmptyReplacement (nes (Proxy :: Proxy "!"))) (nes (Proxy :: Proxy "a[b]c[b]"))
-    , expected: nes (Proxy :: Proxy "a!c!")
-    }
-  assertEqual
-    { actual: NES.replaceAll (Pattern "x") (NES.NonEmptyReplacement (nes (Proxy :: Proxy "!"))) (nes (Proxy :: Proxy "abc"))
-    , expected: nes (Proxy :: Proxy "abc")
-    }
+--   log "replaceAll"
+--   assertEqual
+--     { actual: NES.replaceAll (Pattern "[b]") (NES.NonEmptyReplacement (nes (Proxy :: Proxy "!"))) (nes (Proxy :: Proxy "a[b]c"))
+--     , expected: nes (Proxy :: Proxy "a!c")
+--     }
+--   assertEqual
+--     { actual: NES.replaceAll (Pattern "[b]") (NES.NonEmptyReplacement (nes (Proxy :: Proxy "!"))) (nes (Proxy :: Proxy "a[b]c[b]"))
+--     , expected: nes (Proxy :: Proxy "a!c!")
+--     }
+--   assertEqual
+--     { actual: NES.replaceAll (Pattern "x") (NES.NonEmptyReplacement (nes (Proxy :: Proxy "!"))) (nes (Proxy :: Proxy "abc"))
+--     , expected: nes (Proxy :: Proxy "abc")
+--     }
 
-  log "stripPrefix"
-  assertEqual
-    { actual: NES.stripPrefix (Pattern "") (nes (Proxy :: Proxy "abc"))
-    , expected: Just (nes (Proxy :: Proxy "abc"))
-    }
-  assertEqual
-    { actual: NES.stripPrefix (Pattern "a") (nes (Proxy :: Proxy "abc"))
-    , expected: Just (nes (Proxy :: Proxy "bc"))
-    }
-  assertEqual
-    { actual: NES.stripPrefix (Pattern "abc") (nes (Proxy :: Proxy "abc"))
-    , expected: Nothing
-    }
-  assertEqual
-    { actual: NES.stripPrefix (Pattern "!") (nes (Proxy :: Proxy "abc"))
-    , expected: Nothing
-    }
-  assertEqual
-    { actual: NES.stripPrefix (Pattern "http:") (nes (Proxy :: Proxy "http://purescript.org"))
-    , expected: Just (nes (Proxy :: Proxy "//purescript.org"))
-    }
-  assertEqual
-    { actual: NES.stripPrefix (Pattern "http:") (nes (Proxy :: Proxy "https://purescript.org"))
-    , expected: Nothing
-    }
-  assertEqual
-    { actual: NES.stripPrefix (Pattern "Hello!") (nes (Proxy :: Proxy "Hello!"))
-    , expected: Nothing
-    }
+--   log "stripPrefix"
+--   assertEqual
+--     { actual: NES.stripPrefix (Pattern "") (nes (Proxy :: Proxy "abc"))
+--     , expected: Just (nes (Proxy :: Proxy "abc"))
+--     }
+--   assertEqual
+--     { actual: NES.stripPrefix (Pattern "a") (nes (Proxy :: Proxy "abc"))
+--     , expected: Just (nes (Proxy :: Proxy "bc"))
+--     }
+--   assertEqual
+--     { actual: NES.stripPrefix (Pattern "abc") (nes (Proxy :: Proxy "abc"))
+--     , expected: Nothing
+--     }
+--   assertEqual
+--     { actual: NES.stripPrefix (Pattern "!") (nes (Proxy :: Proxy "abc"))
+--     , expected: Nothing
+--     }
+--   assertEqual
+--     { actual: NES.stripPrefix (Pattern "http:") (nes (Proxy :: Proxy "http://purescript.org"))
+--     , expected: Just (nes (Proxy :: Proxy "//purescript.org"))
+--     }
+--   assertEqual
+--     { actual: NES.stripPrefix (Pattern "http:") (nes (Proxy :: Proxy "https://purescript.org"))
+--     , expected: Nothing
+--     }
+--   assertEqual
+--     { actual: NES.stripPrefix (Pattern "Hello!") (nes (Proxy :: Proxy "Hello!"))
+--     , expected: Nothing
+--     }
 
-  log "stripSuffix"
-  assertEqual
-    { actual: NES.stripSuffix (Pattern ".exe") (nes (Proxy :: Proxy "purs.exe"))
-    , expected: Just (nes (Proxy :: Proxy "purs"))
-    }
-  assertEqual
-    { actual: NES.stripSuffix (Pattern ".exe") (nes (Proxy :: Proxy "purs"))
-    , expected: Nothing
-    }
-  assertEqual
-    { actual: NES.stripSuffix (Pattern "Hello!") (nes (Proxy :: Proxy "Hello!"))
-    , expected: Nothing
-    }
+--   log "stripSuffix"
+--   assertEqual
+--     { actual: NES.stripSuffix (Pattern ".exe") (nes (Proxy :: Proxy "purs.exe"))
+--     , expected: Just (nes (Proxy :: Proxy "purs"))
+--     }
+--   assertEqual
+--     { actual: NES.stripSuffix (Pattern ".exe") (nes (Proxy :: Proxy "purs"))
+--     , expected: Nothing
+--     }
+--   assertEqual
+--     { actual: NES.stripSuffix (Pattern "Hello!") (nes (Proxy :: Proxy "Hello!"))
+--     , expected: Nothing
+--     }
 
-  log "toLower"
-  assertEqual
-    { actual: NES.toLower (nes (Proxy :: Proxy "bAtMaN"))
-    , expected: nes (Proxy :: Proxy "batman")
-    }
+--   log "toLower"
+--   assertEqual
+--     { actual: NES.toLower (nes (Proxy :: Proxy "bAtMaN"))
+--     , expected: nes (Proxy :: Proxy "batman")
+--     }
 
-  log "toUpper"
-  assertEqual
-    { actual: NES.toUpper (nes (Proxy :: Proxy "bAtMaN"))
-    , expected: nes (Proxy :: Proxy "BATMAN")
-    }
+--   log "toUpper"
+--   assertEqual
+--     { actual: NES.toUpper (nes (Proxy :: Proxy "bAtMaN"))
+--     , expected: nes (Proxy :: Proxy "BATMAN")
+--     }
 
-  log "trim"
-  assertEqual
-    { actual: NES.trim (nes (Proxy :: Proxy "  abc  "))
-    , expected: Just (nes (Proxy :: Proxy "abc"))
-    }
-  assertEqual
-    { actual: NES.trim (nes (Proxy :: Proxy "   \n"))
-    , expected: Nothing
-    }
+--   log "trim"
+--   assertEqual
+--     { actual: NES.trim (nes (Proxy :: Proxy "  abc  "))
+--     , expected: Just (nes (Proxy :: Proxy "abc"))
+--     }
+--   assertEqual
+--     { actual: NES.trim (nes (Proxy :: Proxy "   \n"))
+--     , expected: Nothing
+--     }
 
-  log "joinWith"
-  assertEqual
-    { actual: NES.joinWith "" []
-    , expected: ""
-    }
-  assertEqual
-    { actual: NES.joinWith "" [nes (Proxy :: Proxy "a"), nes (Proxy :: Proxy "b")]
-    , expected: "ab"
-    }
-  assertEqual
-    { actual: NES.joinWith "--" [nes (Proxy :: Proxy "a"), nes (Proxy :: Proxy "b"), nes (Proxy :: Proxy "c")]
-    , expected: "a--b--c"
-    }
+--   log "joinWith"
+--   assertEqual
+--     { actual: NES.joinWith "" []
+--     , expected: ""
+--     }
+--   assertEqual
+--     { actual: NES.joinWith "" [nes (Proxy :: Proxy "a"), nes (Proxy :: Proxy "b")]
+--     , expected: "ab"
+--     }
+--   assertEqual
+--     { actual: NES.joinWith "--" [nes (Proxy :: Proxy "a"), nes (Proxy :: Proxy "b"), nes (Proxy :: Proxy "c")]
+--     , expected: "a--b--c"
+--     }
 
-  log "join1With"
-  assertEqual
-    { actual: NES.join1With "" (nea [nes (Proxy :: Proxy "a"), nes (Proxy :: Proxy "b")])
-    , expected: nes (Proxy :: Proxy "ab")
-    }
-  assertEqual
-    { actual: NES.join1With "--" (nea [nes (Proxy :: Proxy "a"), nes (Proxy :: Proxy "b"), nes (Proxy :: Proxy "c")])
-    , expected: nes (Proxy :: Proxy "a--b--c")
-    }
-  assertEqual
-    { actual: NES.join1With ", " (nea [nes (Proxy :: Proxy "apple"), nes (Proxy :: Proxy "banana")])
-    , expected: nes (Proxy :: Proxy "apple, banana")
-    }
-  assertEqual
-    { actual: NES.join1With "" (nea [nes (Proxy :: Proxy "apple"), nes (Proxy :: Proxy "banana")])
-    , expected: nes (Proxy :: Proxy "applebanana")
-    }
+--   log "join1With"
+--   assertEqual
+--     { actual: NES.join1With "" (nea [nes (Proxy :: Proxy "a"), nes (Proxy :: Proxy "b")])
+--     , expected: nes (Proxy :: Proxy "ab")
+--     }
+--   assertEqual
+--     { actual: NES.join1With "--" (nea [nes (Proxy :: Proxy "a"), nes (Proxy :: Proxy "b"), nes (Proxy :: Proxy "c")])
+--     , expected: nes (Proxy :: Proxy "a--b--c")
+--     }
+--   assertEqual
+--     { actual: NES.join1With ", " (nea [nes (Proxy :: Proxy "apple"), nes (Proxy :: Proxy "banana")])
+--     , expected: nes (Proxy :: Proxy "apple, banana")
+--     }
+--   assertEqual
+--     { actual: NES.join1With "" (nea [nes (Proxy :: Proxy "apple"), nes (Proxy :: Proxy "banana")])
+--     , expected: nes (Proxy :: Proxy "applebanana")
+--     }
 
-  log "joinWith1"
-  assertEqual
-    { actual: NES.joinWith1 (nes (Proxy :: Proxy " ")) (nea ["a", "b"])
-    , expected: nes (Proxy :: Proxy "a b")
-    }
-  assertEqual
-    { actual: NES.joinWith1 (nes (Proxy :: Proxy "--")) (nea ["a", "b", "c"])
-    , expected: nes (Proxy :: Proxy "a--b--c")
-    }
-  assertEqual
-    { actual: NES.joinWith1 (nes (Proxy :: Proxy ", ")) (nea ["apple", "banana"])
-    , expected: nes (Proxy :: Proxy "apple, banana")
-    }
-  assertEqual
-    { actual: NES.joinWith1 (nes (Proxy :: Proxy "/")) (nea ["a", "b", "", "c", ""])
-    , expected: nes (Proxy :: Proxy "a/b//c/")
-    }
+--   log "joinWith1"
+--   assertEqual
+--     { actual: NES.joinWith1 (nes (Proxy :: Proxy " ")) (nea ["a", "b"])
+--     , expected: nes (Proxy :: Proxy "a b")
+--     }
+--   assertEqual
+--     { actual: NES.joinWith1 (nes (Proxy :: Proxy "--")) (nea ["a", "b", "c"])
+--     , expected: nes (Proxy :: Proxy "a--b--c")
+--     }
+--   assertEqual
+--     { actual: NES.joinWith1 (nes (Proxy :: Proxy ", ")) (nea ["apple", "banana"])
+--     , expected: nes (Proxy :: Proxy "apple, banana")
+--     }
+--   assertEqual
+--     { actual: NES.joinWith1 (nes (Proxy :: Proxy "/")) (nea ["a", "b", "", "c", ""])
+--     , expected: nes (Proxy :: Proxy "a/b//c/")
+--     }
 
-nea :: Array ~> NEA.NonEmptyArray
-nea = unsafePartial fromJust <<< NEA.fromArray
+-- nea :: Array ~> NEA.NonEmptyArray
+-- nea = unsafePartial fromJust <<< NEA.fromArray

--- a/test/Test/Data/String/NonEmpty/CodeUnits.purs
+++ b/test/Test/Data/String/NonEmpty/CodeUnits.purs
@@ -1,450 +1,451 @@
-module Test.Data.String.NonEmpty.CodeUnits (testNonEmptyStringCodeUnits) where
+-- module Test.Data.String.NonEmpty.CodeUnits (testNonEmptyStringCodeUnits) where
+module Test.Data.String.NonEmpty.CodeUnits where
 
-import Prelude
+-- import Prelude
 
-import Data.Array.NonEmpty as NEA
-import Data.Enum (fromEnum)
-import Data.Maybe (Maybe(..), fromJust)
-import Data.String.NonEmpty (Pattern(..), nes)
-import Data.String.NonEmpty.CodeUnits as NESCU
-import Effect (Effect)
-import Effect.Console (log)
-import Partial.Unsafe (unsafePartial)
-import Test.Assert (assertEqual)
-import Type.Proxy (Proxy(..))
+-- import Data.Array.NonEmpty as NEA
+-- import Data.Enum (fromEnum)
+-- import Data.Maybe (Maybe(..), fromJust)
+-- import Data.String.NonEmpty (Pattern(..), nes)
+-- import Data.String.NonEmpty.CodeUnits as NESCU
+-- import Effect (Effect)
+-- import Effect.Console (log)
+-- import Partial.Unsafe (unsafePartial)
+-- import Test.Assert (assertEqual)
+-- import Type.Proxy (Proxy(..))
 
-testNonEmptyStringCodeUnits :: Effect Unit
-testNonEmptyStringCodeUnits = do
+-- testNonEmptyStringCodeUnits :: Effect Unit
+-- testNonEmptyStringCodeUnits = do
 
-  log "fromCharArray"
-  assertEqual
-    { actual: NESCU.fromCharArray []
-    , expected: Nothing
-    }
-  assertEqual
-    { actual: NESCU.fromCharArray ['a', 'b']
-    , expected: Just (nes (Proxy :: Proxy "ab"))
-    }
+--   log "fromCharArray"
+--   assertEqual
+--     { actual: NESCU.fromCharArray []
+--     , expected: Nothing
+--     }
+--   assertEqual
+--     { actual: NESCU.fromCharArray ['a', 'b']
+--     , expected: Just (nes (Proxy :: Proxy "ab"))
+--     }
 
-  log "fromNonEmptyCharArray"
-  assertEqual
-    { actual: NESCU.fromNonEmptyCharArray (NEA.singleton 'b')
-    , expected: NESCU.singleton 'b'
-    }
+--   log "fromNonEmptyCharArray"
+--   assertEqual
+--     { actual: NESCU.fromNonEmptyCharArray (NEA.singleton 'b')
+--     , expected: NESCU.singleton 'b'
+--     }
 
-  log "singleton"
-  assertEqual
-    { actual: NESCU.singleton 'a'
-    , expected: nes (Proxy :: Proxy "a")
-    }
+--   log "singleton"
+--   assertEqual
+--     { actual: NESCU.singleton 'a'
+--     , expected: nes (Proxy :: Proxy "a")
+--     }
 
-  log "cons"
-  assertEqual
-    { actual: NESCU.cons 'a' "bc"
-    , expected: nes (Proxy :: Proxy "abc")
-    }
-  assertEqual
-    { actual: NESCU.cons 'a' ""
-    , expected: nes (Proxy :: Proxy "a")
-    }
+--   log "cons"
+--   assertEqual
+--     { actual: NESCU.cons 'a' "bc"
+--     , expected: nes (Proxy :: Proxy "abc")
+--     }
+--   assertEqual
+--     { actual: NESCU.cons 'a' ""
+--     , expected: nes (Proxy :: Proxy "a")
+--     }
 
-  log "snoc"
-  assertEqual
-    { actual: NESCU.snoc 'c' "ab"
-    , expected: nes (Proxy :: Proxy "abc")
-    }
-  assertEqual
-    { actual: NESCU.snoc 'a' ""
-    , expected: nes (Proxy :: Proxy "a")
-    }
+--   log "snoc"
+--   assertEqual
+--     { actual: NESCU.snoc 'c' "ab"
+--     , expected: nes (Proxy :: Proxy "abc")
+--     }
+--   assertEqual
+--     { actual: NESCU.snoc 'a' ""
+--     , expected: nes (Proxy :: Proxy "a")
+--     }
 
-  log "fromFoldable1"
-  assertEqual
-    { actual: NESCU.fromFoldable1 (nea ['a'])
-    , expected: nes (Proxy :: Proxy "a")
-    }
-  assertEqual
-    { actual: NESCU.fromFoldable1 (nea ['a', 'b', 'c'])
-    , expected: nes (Proxy :: Proxy "abc")
-    }
+--   log "fromFoldable1"
+--   assertEqual
+--     { actual: NESCU.fromFoldable1 (nea ['a'])
+--     , expected: nes (Proxy :: Proxy "a")
+--     }
+--   assertEqual
+--     { actual: NESCU.fromFoldable1 (nea ['a', 'b', 'c'])
+--     , expected: nes (Proxy :: Proxy "abc")
+--     }
 
-  log "charAt"
-  assertEqual
-    { actual: NESCU.charAt 0 (nes (Proxy :: Proxy "a"))
-    , expected: Just 'a'
-    }
-  assertEqual
-    { actual: NESCU.charAt 1 (nes (Proxy :: Proxy "a"))
-    , expected: Nothing
-    }
-  assertEqual
-    { actual: NESCU.charAt 0 (nes (Proxy :: Proxy "ab"))
-    , expected: Just 'a'
-    }
-  assertEqual
-    { actual: NESCU.charAt 1 (nes (Proxy :: Proxy "ab"))
-    , expected: Just 'b'
-    }
-  assertEqual
-    { actual: NESCU.charAt 2 (nes (Proxy :: Proxy "ab"))
-    , expected: Nothing
-    }
-  assertEqual
-    { actual: NESCU.charAt 2 (nes (Proxy :: Proxy "Hello"))
-    , expected: Just 'l'
-    }
-  assertEqual
-    { actual: NESCU.charAt 10 (nes (Proxy :: Proxy "Hello"))
-    , expected: Nothing
-    }
+--   log "charAt"
+--   assertEqual
+--     { actual: NESCU.charAt 0 (nes (Proxy :: Proxy "a"))
+--     , expected: Just 'a'
+--     }
+--   assertEqual
+--     { actual: NESCU.charAt 1 (nes (Proxy :: Proxy "a"))
+--     , expected: Nothing
+--     }
+--   assertEqual
+--     { actual: NESCU.charAt 0 (nes (Proxy :: Proxy "ab"))
+--     , expected: Just 'a'
+--     }
+--   assertEqual
+--     { actual: NESCU.charAt 1 (nes (Proxy :: Proxy "ab"))
+--     , expected: Just 'b'
+--     }
+--   assertEqual
+--     { actual: NESCU.charAt 2 (nes (Proxy :: Proxy "ab"))
+--     , expected: Nothing
+--     }
+--   assertEqual
+--     { actual: NESCU.charAt 2 (nes (Proxy :: Proxy "Hello"))
+--     , expected: Just 'l'
+--     }
+--   assertEqual
+--     { actual: NESCU.charAt 10 (nes (Proxy :: Proxy "Hello"))
+--     , expected: Nothing
+--     }
 
-  log "charCodeAt"
-  assertEqual
-    { actual: fromEnum <$> NESCU.charAt 0 (nes (Proxy :: Proxy "a"))
-    , expected: Just 97
-    }
-  assertEqual
-    { actual: fromEnum <$> NESCU.charAt 1 (nes (Proxy :: Proxy "a"))
-    , expected: Nothing
-    }
-  assertEqual
-    { actual: fromEnum <$> NESCU.charAt 0 (nes (Proxy :: Proxy "ab"))
-    , expected: Just 97
-    }
-  assertEqual
-    { actual: fromEnum <$> NESCU.charAt 1 (nes (Proxy :: Proxy "ab"))
-    , expected: Just 98
-    }
-  assertEqual
-    { actual: fromEnum <$> NESCU.charAt 2 (nes (Proxy :: Proxy "ab"))
-    , expected: Nothing
-    }
-  assertEqual
-    { actual: fromEnum <$> NESCU.charAt 2 (nes (Proxy :: Proxy "5 €"))
-    , expected: Just 0x20AC
-    }
-  assertEqual
-    { actual: fromEnum <$> NESCU.charAt 10 (nes (Proxy :: Proxy "5 €"))
-    , expected: Nothing
-    }
+--   log "charCodeAt"
+--   assertEqual
+--     { actual: fromEnum <$> NESCU.charAt 0 (nes (Proxy :: Proxy "a"))
+--     , expected: Just 97
+--     }
+--   assertEqual
+--     { actual: fromEnum <$> NESCU.charAt 1 (nes (Proxy :: Proxy "a"))
+--     , expected: Nothing
+--     }
+--   assertEqual
+--     { actual: fromEnum <$> NESCU.charAt 0 (nes (Proxy :: Proxy "ab"))
+--     , expected: Just 97
+--     }
+--   assertEqual
+--     { actual: fromEnum <$> NESCU.charAt 1 (nes (Proxy :: Proxy "ab"))
+--     , expected: Just 98
+--     }
+--   assertEqual
+--     { actual: fromEnum <$> NESCU.charAt 2 (nes (Proxy :: Proxy "ab"))
+--     , expected: Nothing
+--     }
+--   assertEqual
+--     { actual: fromEnum <$> NESCU.charAt 2 (nes (Proxy :: Proxy "5 €"))
+--     , expected: Just 0x20AC
+--     }
+--   assertEqual
+--     { actual: fromEnum <$> NESCU.charAt 10 (nes (Proxy :: Proxy "5 €"))
+--     , expected: Nothing
+--     }
 
-  log "toChar"
-  assertEqual
-    { actual: NESCU.toChar (nes (Proxy :: Proxy "a"))
-    , expected: Just 'a'
-    }
-  assertEqual
-    { actual: NESCU.toChar (nes (Proxy :: Proxy "ab"))
-    , expected: Nothing
-    }
+--   log "toChar"
+--   assertEqual
+--     { actual: NESCU.toChar (nes (Proxy :: Proxy "a"))
+--     , expected: Just 'a'
+--     }
+--   assertEqual
+--     { actual: NESCU.toChar (nes (Proxy :: Proxy "ab"))
+--     , expected: Nothing
+--     }
 
-  log "toCharArray"
-  assertEqual
-    { actual: NESCU.toCharArray (nes (Proxy :: Proxy "a"))
-    , expected: ['a']
-    }
-  assertEqual
-    { actual: NESCU.toCharArray (nes (Proxy :: Proxy "ab"))
-    , expected: ['a', 'b']
-    }
-  assertEqual
-    { actual: NESCU.toCharArray (nes (Proxy :: Proxy "Hello☺\n"))
-    , expected: ['H','e','l','l','o','☺','\n']
-    }
+--   log "toCharArray"
+--   assertEqual
+--     { actual: NESCU.toCharArray (nes (Proxy :: Proxy "a"))
+--     , expected: ['a']
+--     }
+--   assertEqual
+--     { actual: NESCU.toCharArray (nes (Proxy :: Proxy "ab"))
+--     , expected: ['a', 'b']
+--     }
+--   assertEqual
+--     { actual: NESCU.toCharArray (nes (Proxy :: Proxy "Hello☺\n"))
+--     , expected: ['H','e','l','l','o','☺','\n']
+--     }
 
-  log "toNonEmptyCharArray"
-  assertEqual
-    { actual: NESCU.toNonEmptyCharArray (nes (Proxy :: Proxy "ab"))
-    , expected: nea ['a', 'b']
-    }
+--   log "toNonEmptyCharArray"
+--   assertEqual
+--     { actual: NESCU.toNonEmptyCharArray (nes (Proxy :: Proxy "ab"))
+--     , expected: nea ['a', 'b']
+--     }
 
-  log "uncons"
-  assertEqual
-    { actual: NESCU.uncons (nes (Proxy :: Proxy "a"))
-    , expected: { head: 'a', tail: Nothing }
-    }
-  assertEqual
-    { actual: NESCU.uncons (nes (Proxy :: Proxy "Hello World"))
-    , expected: { head: 'H', tail: Just (nes (Proxy :: Proxy "ello World")) }
-    }
+--   log "uncons"
+--   assertEqual
+--     { actual: NESCU.uncons (nes (Proxy :: Proxy "a"))
+--     , expected: { head: 'a', tail: Nothing }
+--     }
+--   assertEqual
+--     { actual: NESCU.uncons (nes (Proxy :: Proxy "Hello World"))
+--     , expected: { head: 'H', tail: Just (nes (Proxy :: Proxy "ello World")) }
+--     }
 
-  log "takeWhile"
-  assertEqual
-    { actual: NESCU.takeWhile (\_ -> true) (nes (Proxy :: Proxy "abc"))
-    , expected: Just (nes (Proxy :: Proxy "abc"))
-    }
-  assertEqual
-    { actual: NESCU.takeWhile (\_ -> false) (nes (Proxy :: Proxy "abc"))
-    , expected: Nothing
-    }
-  assertEqual
-    { actual: NESCU.takeWhile (\c -> c /= 'b') (nes (Proxy :: Proxy "aabbcc"))
-    , expected: Just (nes (Proxy :: Proxy "aa"))
-    }
-  assertEqual
-    { actual: NESCU.takeWhile (_ /= ':') (nes (Proxy :: Proxy "http://purescript.org"))
-    , expected: Just (nes (Proxy :: Proxy "http"))
-    }
-  assertEqual
-    { actual: NESCU.takeWhile (_ == 'a') (nes (Proxy :: Proxy "xyz"))
-    , expected: Nothing
-    }
+--   log "takeWhile"
+--   assertEqual
+--     { actual: NESCU.takeWhile (\_ -> true) (nes (Proxy :: Proxy "abc"))
+--     , expected: Just (nes (Proxy :: Proxy "abc"))
+--     }
+--   assertEqual
+--     { actual: NESCU.takeWhile (\_ -> false) (nes (Proxy :: Proxy "abc"))
+--     , expected: Nothing
+--     }
+--   assertEqual
+--     { actual: NESCU.takeWhile (\c -> c /= 'b') (nes (Proxy :: Proxy "aabbcc"))
+--     , expected: Just (nes (Proxy :: Proxy "aa"))
+--     }
+--   assertEqual
+--     { actual: NESCU.takeWhile (_ /= ':') (nes (Proxy :: Proxy "http://purescript.org"))
+--     , expected: Just (nes (Proxy :: Proxy "http"))
+--     }
+--   assertEqual
+--     { actual: NESCU.takeWhile (_ == 'a') (nes (Proxy :: Proxy "xyz"))
+--     , expected: Nothing
+--     }
 
-  log "dropWhile"
-  assertEqual
-    { actual: NESCU.dropWhile (\_ -> true) (nes (Proxy :: Proxy "abc"))
-    , expected: Nothing
-    }
-  assertEqual
-    { actual: NESCU.dropWhile (\_ -> false) (nes (Proxy :: Proxy "abc"))
-    , expected: Just (nes (Proxy :: Proxy "abc"))
-    }
-  assertEqual
-    { actual: NESCU.dropWhile (\c -> c /= 'b') (nes (Proxy :: Proxy "aabbcc"))
-    , expected: Just (nes (Proxy :: Proxy "bbcc"))
-    }
-  assertEqual
-    { actual: NESCU.dropWhile (_ /= '.') (nes (Proxy :: Proxy "Test.purs"))
-    , expected: Just (nes (Proxy :: Proxy ".purs"))
-    }
+--   log "dropWhile"
+--   assertEqual
+--     { actual: NESCU.dropWhile (\_ -> true) (nes (Proxy :: Proxy "abc"))
+--     , expected: Nothing
+--     }
+--   assertEqual
+--     { actual: NESCU.dropWhile (\_ -> false) (nes (Proxy :: Proxy "abc"))
+--     , expected: Just (nes (Proxy :: Proxy "abc"))
+--     }
+--   assertEqual
+--     { actual: NESCU.dropWhile (\c -> c /= 'b') (nes (Proxy :: Proxy "aabbcc"))
+--     , expected: Just (nes (Proxy :: Proxy "bbcc"))
+--     }
+--   assertEqual
+--     { actual: NESCU.dropWhile (_ /= '.') (nes (Proxy :: Proxy "Test.purs"))
+--     , expected: Just (nes (Proxy :: Proxy ".purs"))
+--     }
 
-  log "indexOf"
-  assertEqual
-    { actual: NESCU.indexOf (Pattern "") (nes (Proxy :: Proxy "abcd"))
-    , expected: Just 0
-    }
-  assertEqual
-    { actual: NESCU.indexOf (Pattern "bc") (nes (Proxy :: Proxy "abcd"))
-    , expected: Just 1
-    }
-  assertEqual
-    { actual: NESCU.indexOf (Pattern "cb") (nes (Proxy :: Proxy "abcd"))
-    , expected: Nothing
-    }
+--   log "indexOf"
+--   assertEqual
+--     { actual: NESCU.indexOf (Pattern "") (nes (Proxy :: Proxy "abcd"))
+--     , expected: Just 0
+--     }
+--   assertEqual
+--     { actual: NESCU.indexOf (Pattern "bc") (nes (Proxy :: Proxy "abcd"))
+--     , expected: Just 1
+--     }
+--   assertEqual
+--     { actual: NESCU.indexOf (Pattern "cb") (nes (Proxy :: Proxy "abcd"))
+--     , expected: Nothing
+--     }
 
-  log "indexOf'"
-  assertEqual
-    { actual: NESCU.indexOf' (Pattern "") (-1) (nes (Proxy :: Proxy "ab"))
-    , expected: Nothing
-    }
-  assertEqual
-    { actual: NESCU.indexOf' (Pattern "") 0 (nes (Proxy :: Proxy "ab"))
-    , expected: Just 0
-    }
-  assertEqual
-    { actual: NESCU.indexOf' (Pattern "") 1 (nes (Proxy :: Proxy "ab"))
-    , expected: Just 1
-    }
-  assertEqual
-    { actual: NESCU.indexOf' (Pattern "") 2 (nes (Proxy :: Proxy "ab"))
-    , expected: Just 2
-    }
-  assertEqual
-    { actual: NESCU.indexOf' (Pattern "") 3 (nes (Proxy :: Proxy "ab"))
-    , expected: Nothing
-    }
-  assertEqual
-    { actual: NESCU.indexOf' (Pattern "bc") 0 (nes (Proxy :: Proxy "abcd"))
-    , expected: Just 1
-    }
-  assertEqual
-    { actual: NESCU.indexOf' (Pattern "bc") 1 (nes (Proxy :: Proxy "abcd"))
-    , expected: Just 1
-    }
-  assertEqual
-    { actual: NESCU.indexOf' (Pattern "bc") 2 (nes (Proxy :: Proxy "abcd"))
-    , expected: Nothing
-    }
-  assertEqual
-    { actual: NESCU.indexOf' (Pattern "cb") 0 (nes (Proxy :: Proxy "abcd"))
-    , expected: Nothing
-    }
+--   log "indexOf'"
+--   assertEqual
+--     { actual: NESCU.indexOf' (Pattern "") (-1) (nes (Proxy :: Proxy "ab"))
+--     , expected: Nothing
+--     }
+--   assertEqual
+--     { actual: NESCU.indexOf' (Pattern "") 0 (nes (Proxy :: Proxy "ab"))
+--     , expected: Just 0
+--     }
+--   assertEqual
+--     { actual: NESCU.indexOf' (Pattern "") 1 (nes (Proxy :: Proxy "ab"))
+--     , expected: Just 1
+--     }
+--   assertEqual
+--     { actual: NESCU.indexOf' (Pattern "") 2 (nes (Proxy :: Proxy "ab"))
+--     , expected: Just 2
+--     }
+--   assertEqual
+--     { actual: NESCU.indexOf' (Pattern "") 3 (nes (Proxy :: Proxy "ab"))
+--     , expected: Nothing
+--     }
+--   assertEqual
+--     { actual: NESCU.indexOf' (Pattern "bc") 0 (nes (Proxy :: Proxy "abcd"))
+--     , expected: Just 1
+--     }
+--   assertEqual
+--     { actual: NESCU.indexOf' (Pattern "bc") 1 (nes (Proxy :: Proxy "abcd"))
+--     , expected: Just 1
+--     }
+--   assertEqual
+--     { actual: NESCU.indexOf' (Pattern "bc") 2 (nes (Proxy :: Proxy "abcd"))
+--     , expected: Nothing
+--     }
+--   assertEqual
+--     { actual: NESCU.indexOf' (Pattern "cb") 0 (nes (Proxy :: Proxy "abcd"))
+--     , expected: Nothing
+--     }
 
-  log "lastIndexOf"
-  assertEqual
-    { actual: NESCU.lastIndexOf (Pattern "") (nes (Proxy :: Proxy "abcd"))
-    , expected: Just 4
-    }
-  assertEqual
-    { actual: NESCU.lastIndexOf (Pattern "bc") (nes (Proxy :: Proxy "abcd"))
-    , expected: Just 1
-    }
-  assertEqual
-    { actual: NESCU.lastIndexOf (Pattern "cb") (nes (Proxy :: Proxy "abcd"))
-    , expected: Nothing
-    }
+--   log "lastIndexOf"
+--   assertEqual
+--     { actual: NESCU.lastIndexOf (Pattern "") (nes (Proxy :: Proxy "abcd"))
+--     , expected: Just 4
+--     }
+--   assertEqual
+--     { actual: NESCU.lastIndexOf (Pattern "bc") (nes (Proxy :: Proxy "abcd"))
+--     , expected: Just 1
+--     }
+--   assertEqual
+--     { actual: NESCU.lastIndexOf (Pattern "cb") (nes (Proxy :: Proxy "abcd"))
+--     , expected: Nothing
+--     }
 
-  log "lastIndexOf'"
-  assertEqual
-    { actual: NESCU.lastIndexOf' (Pattern "") (-1) (nes (Proxy :: Proxy "ab"))
-    , expected: Just 0
-    }
-  assertEqual
-    { actual: NESCU.lastIndexOf' (Pattern "") 0 (nes (Proxy :: Proxy "ab"))
-    , expected: Just 0
-    }
-  assertEqual
-    { actual: NESCU.lastIndexOf' (Pattern "") 1 (nes (Proxy :: Proxy "ab"))
-    , expected: Just 1
-    }
-  assertEqual
-    { actual: NESCU.lastIndexOf' (Pattern "") 2 (nes (Proxy :: Proxy "ab"))
-    , expected: Just 2
-    }
-  assertEqual
-    { actual: NESCU.lastIndexOf' (Pattern "") 3 (nes (Proxy :: Proxy "ab"))
-    , expected: Just 2
-    }
-  assertEqual
-    { actual: NESCU.lastIndexOf' (Pattern "bc") 0 (nes (Proxy :: Proxy "abcd"))
-    , expected: Nothing
-    }
-  assertEqual
-    { actual: NESCU.lastIndexOf' (Pattern "bc") 1 (nes (Proxy :: Proxy "abcd"))
-    , expected: Just 1
-    }
-  assertEqual
-    { actual: NESCU.lastIndexOf' (Pattern "bc") 2 (nes (Proxy :: Proxy "abcd"))
-    , expected: Just 1
-    }
-  assertEqual
-    { actual: NESCU.lastIndexOf' (Pattern "cb") 0 (nes (Proxy :: Proxy "abcd"))
-    , expected: Nothing
-    }
+--   log "lastIndexOf'"
+--   assertEqual
+--     { actual: NESCU.lastIndexOf' (Pattern "") (-1) (nes (Proxy :: Proxy "ab"))
+--     , expected: Just 0
+--     }
+--   assertEqual
+--     { actual: NESCU.lastIndexOf' (Pattern "") 0 (nes (Proxy :: Proxy "ab"))
+--     , expected: Just 0
+--     }
+--   assertEqual
+--     { actual: NESCU.lastIndexOf' (Pattern "") 1 (nes (Proxy :: Proxy "ab"))
+--     , expected: Just 1
+--     }
+--   assertEqual
+--     { actual: NESCU.lastIndexOf' (Pattern "") 2 (nes (Proxy :: Proxy "ab"))
+--     , expected: Just 2
+--     }
+--   assertEqual
+--     { actual: NESCU.lastIndexOf' (Pattern "") 3 (nes (Proxy :: Proxy "ab"))
+--     , expected: Just 2
+--     }
+--   assertEqual
+--     { actual: NESCU.lastIndexOf' (Pattern "bc") 0 (nes (Proxy :: Proxy "abcd"))
+--     , expected: Nothing
+--     }
+--   assertEqual
+--     { actual: NESCU.lastIndexOf' (Pattern "bc") 1 (nes (Proxy :: Proxy "abcd"))
+--     , expected: Just 1
+--     }
+--   assertEqual
+--     { actual: NESCU.lastIndexOf' (Pattern "bc") 2 (nes (Proxy :: Proxy "abcd"))
+--     , expected: Just 1
+--     }
+--   assertEqual
+--     { actual: NESCU.lastIndexOf' (Pattern "cb") 0 (nes (Proxy :: Proxy "abcd"))
+--     , expected: Nothing
+--     }
 
-  log "length"
-  assertEqual
-    { actual: NESCU.length (nes (Proxy :: Proxy "a"))
-    , expected: 1
-    }
-  assertEqual
-    { actual: NESCU.length (nes (Proxy :: Proxy "ab"))
-    , expected: 2
-    }
+--   log "length"
+--   assertEqual
+--     { actual: NESCU.length (nes (Proxy :: Proxy "a"))
+--     , expected: 1
+--     }
+--   assertEqual
+--     { actual: NESCU.length (nes (Proxy :: Proxy "ab"))
+--     , expected: 2
+--     }
 
-  log "take"
-  assertEqual
-    { actual: NESCU.take 0 (nes (Proxy :: Proxy "ab"))
-    , expected: Nothing
-    }
-  assertEqual
-    { actual: NESCU.take 1 (nes (Proxy :: Proxy "ab"))
-    , expected: Just (nes (Proxy :: Proxy "a"))
-    }
-  assertEqual
-    { actual: NESCU.take 2 (nes (Proxy :: Proxy "ab"))
-    , expected: Just (nes (Proxy :: Proxy "ab"))
-    }
-  assertEqual
-    { actual: NESCU.take 3 (nes (Proxy :: Proxy "ab"))
-    , expected: Just (nes (Proxy :: Proxy "ab"))
-    }
-  assertEqual
-    { actual: NESCU.take (-1) (nes (Proxy :: Proxy "ab"))
-    , expected: Nothing
-    }
+--   log "take"
+--   assertEqual
+--     { actual: NESCU.take 0 (nes (Proxy :: Proxy "ab"))
+--     , expected: Nothing
+--     }
+--   assertEqual
+--     { actual: NESCU.take 1 (nes (Proxy :: Proxy "ab"))
+--     , expected: Just (nes (Proxy :: Proxy "a"))
+--     }
+--   assertEqual
+--     { actual: NESCU.take 2 (nes (Proxy :: Proxy "ab"))
+--     , expected: Just (nes (Proxy :: Proxy "ab"))
+--     }
+--   assertEqual
+--     { actual: NESCU.take 3 (nes (Proxy :: Proxy "ab"))
+--     , expected: Just (nes (Proxy :: Proxy "ab"))
+--     }
+--   assertEqual
+--     { actual: NESCU.take (-1) (nes (Proxy :: Proxy "ab"))
+--     , expected: Nothing
+--     }
 
-  log "takeRight"
-  assertEqual
-    { actual: NESCU.takeRight 0 (nes (Proxy :: Proxy "ab"))
-    , expected: Nothing
-    }
-  assertEqual
-    { actual: NESCU.takeRight 1 (nes (Proxy :: Proxy "ab"))
-    , expected: Just (nes (Proxy :: Proxy "b"))
-    }
-  assertEqual
-    { actual: NESCU.takeRight 2 (nes (Proxy :: Proxy "ab"))
-    , expected: Just (nes (Proxy :: Proxy "ab"))
-    }
-  assertEqual
-    { actual: NESCU.takeRight 3 (nes (Proxy :: Proxy "ab"))
-    , expected: Just (nes (Proxy :: Proxy "ab"))
-    }
-  assertEqual
-    { actual: NESCU.takeRight (-1) (nes (Proxy :: Proxy "ab"))
-    , expected: Nothing
-    }
+--   log "takeRight"
+--   assertEqual
+--     { actual: NESCU.takeRight 0 (nes (Proxy :: Proxy "ab"))
+--     , expected: Nothing
+--     }
+--   assertEqual
+--     { actual: NESCU.takeRight 1 (nes (Proxy :: Proxy "ab"))
+--     , expected: Just (nes (Proxy :: Proxy "b"))
+--     }
+--   assertEqual
+--     { actual: NESCU.takeRight 2 (nes (Proxy :: Proxy "ab"))
+--     , expected: Just (nes (Proxy :: Proxy "ab"))
+--     }
+--   assertEqual
+--     { actual: NESCU.takeRight 3 (nes (Proxy :: Proxy "ab"))
+--     , expected: Just (nes (Proxy :: Proxy "ab"))
+--     }
+--   assertEqual
+--     { actual: NESCU.takeRight (-1) (nes (Proxy :: Proxy "ab"))
+--     , expected: Nothing
+--     }
 
-  log "drop"
-  assertEqual
-    { actual: NESCU.drop 0 (nes (Proxy :: Proxy "ab"))
-    , expected: Just (nes (Proxy :: Proxy "ab"))
-    }
-  assertEqual
-    { actual: NESCU.drop 1 (nes (Proxy :: Proxy "ab"))
-    , expected: Just (nes (Proxy :: Proxy "b"))
-    }
-  assertEqual
-    { actual: NESCU.drop 2 (nes (Proxy :: Proxy "ab"))
-    , expected: Nothing
-    }
-  assertEqual
-    { actual: NESCU.drop 3 (nes (Proxy :: Proxy "ab"))
-    , expected: Nothing
-    }
-  assertEqual
-    { actual: NESCU.drop (-1) (nes (Proxy :: Proxy "ab"))
-    , expected: Just (nes (Proxy :: Proxy "ab"))
-    }
+--   log "drop"
+--   assertEqual
+--     { actual: NESCU.drop 0 (nes (Proxy :: Proxy "ab"))
+--     , expected: Just (nes (Proxy :: Proxy "ab"))
+--     }
+--   assertEqual
+--     { actual: NESCU.drop 1 (nes (Proxy :: Proxy "ab"))
+--     , expected: Just (nes (Proxy :: Proxy "b"))
+--     }
+--   assertEqual
+--     { actual: NESCU.drop 2 (nes (Proxy :: Proxy "ab"))
+--     , expected: Nothing
+--     }
+--   assertEqual
+--     { actual: NESCU.drop 3 (nes (Proxy :: Proxy "ab"))
+--     , expected: Nothing
+--     }
+--   assertEqual
+--     { actual: NESCU.drop (-1) (nes (Proxy :: Proxy "ab"))
+--     , expected: Just (nes (Proxy :: Proxy "ab"))
+--     }
 
-  log "dropRight"
-  assertEqual
-    { actual: NESCU.dropRight 0 (nes (Proxy :: Proxy "ab"))
-    , expected: Just (nes (Proxy :: Proxy "ab"))
-    }
-  assertEqual
-    { actual: NESCU.dropRight 1 (nes (Proxy :: Proxy "ab"))
-    , expected: Just (nes (Proxy :: Proxy "a"))
-    }
-  assertEqual
-    { actual: NESCU.dropRight 2 (nes (Proxy :: Proxy "ab"))
-    , expected: Nothing
-    }
-  assertEqual
-    { actual: NESCU.dropRight 3 (nes (Proxy :: Proxy "ab"))
-    , expected: Nothing
-    }
-  assertEqual
-    { actual: NESCU.dropRight (-1) (nes (Proxy :: Proxy "ab"))
-    , expected: Just (nes (Proxy :: Proxy "ab"))
-    }
+--   log "dropRight"
+--   assertEqual
+--     { actual: NESCU.dropRight 0 (nes (Proxy :: Proxy "ab"))
+--     , expected: Just (nes (Proxy :: Proxy "ab"))
+--     }
+--   assertEqual
+--     { actual: NESCU.dropRight 1 (nes (Proxy :: Proxy "ab"))
+--     , expected: Just (nes (Proxy :: Proxy "a"))
+--     }
+--   assertEqual
+--     { actual: NESCU.dropRight 2 (nes (Proxy :: Proxy "ab"))
+--     , expected: Nothing
+--     }
+--   assertEqual
+--     { actual: NESCU.dropRight 3 (nes (Proxy :: Proxy "ab"))
+--     , expected: Nothing
+--     }
+--   assertEqual
+--     { actual: NESCU.dropRight (-1) (nes (Proxy :: Proxy "ab"))
+--     , expected: Just (nes (Proxy :: Proxy "ab"))
+--     }
 
-  log "countPrefix"
-  assertEqual
-    { actual: NESCU.countPrefix (_ == 'a') (nes (Proxy :: Proxy "ab"))
-    , expected: 1
-    }
-  assertEqual
-    { actual: NESCU.countPrefix (_ == 'a') (nes (Proxy :: Proxy "aaab"))
-    , expected: 3
-    }
-  assertEqual
-    { actual: NESCU.countPrefix (_ == 'a') (nes (Proxy :: Proxy "abaa"))
-    , expected: 1
-    }
-  assertEqual
-    { actual: NESCU.countPrefix (_ == 'c') (nes (Proxy :: Proxy "abaa"))
-    , expected: 0
-    }
+--   log "countPrefix"
+--   assertEqual
+--     { actual: NESCU.countPrefix (_ == 'a') (nes (Proxy :: Proxy "ab"))
+--     , expected: 1
+--     }
+--   assertEqual
+--     { actual: NESCU.countPrefix (_ == 'a') (nes (Proxy :: Proxy "aaab"))
+--     , expected: 3
+--     }
+--   assertEqual
+--     { actual: NESCU.countPrefix (_ == 'a') (nes (Proxy :: Proxy "abaa"))
+--     , expected: 1
+--     }
+--   assertEqual
+--     { actual: NESCU.countPrefix (_ == 'c') (nes (Proxy :: Proxy "abaa"))
+--     , expected: 0
+--     }
 
-  log "splitAt"
-  assertEqual
-    { actual: NESCU.splitAt 0 (nes (Proxy :: Proxy "a"))
-    , expected: { before: Nothing, after: Just (nes (Proxy :: Proxy "a")) }
-    }
-  assertEqual
-    { actual: NESCU.splitAt 1 (nes (Proxy :: Proxy "ab"))
-    , expected: { before: Just (nes (Proxy :: Proxy "a")), after: Just (nes (Proxy :: Proxy "b")) }
-    }
-  assertEqual
-    { actual: NESCU.splitAt 3 (nes (Proxy :: Proxy "aabcc"))
-    , expected: { before: Just (nes (Proxy :: Proxy "aab")), after: Just (nes (Proxy :: Proxy "cc")) }
-    }
-  assertEqual
-    { actual: NESCU.splitAt (-1) (nes (Proxy :: Proxy "abc"))
-    , expected: { before: Nothing, after: Just (nes (Proxy :: Proxy "abc")) }
-    }
+--   log "splitAt"
+--   assertEqual
+--     { actual: NESCU.splitAt 0 (nes (Proxy :: Proxy "a"))
+--     , expected: { before: Nothing, after: Just (nes (Proxy :: Proxy "a")) }
+--     }
+--   assertEqual
+--     { actual: NESCU.splitAt 1 (nes (Proxy :: Proxy "ab"))
+--     , expected: { before: Just (nes (Proxy :: Proxy "a")), after: Just (nes (Proxy :: Proxy "b")) }
+--     }
+--   assertEqual
+--     { actual: NESCU.splitAt 3 (nes (Proxy :: Proxy "aabcc"))
+--     , expected: { before: Just (nes (Proxy :: Proxy "aab")), after: Just (nes (Proxy :: Proxy "cc")) }
+--     }
+--   assertEqual
+--     { actual: NESCU.splitAt (-1) (nes (Proxy :: Proxy "abc"))
+--     , expected: { before: Nothing, after: Just (nes (Proxy :: Proxy "abc")) }
+--     }
 
-nea :: Array ~> NEA.NonEmptyArray
-nea = unsafePartial fromJust <<< NEA.fromArray
+-- nea :: Array ~> NEA.NonEmptyArray
+-- nea = unsafePartial fromJust <<< NEA.fromArray

--- a/test/Test/Data/String/Regex.purs
+++ b/test/Test/Data/String/Regex.purs
@@ -1,61 +1,62 @@
-module Test.Data.String.Regex (testStringRegex) where
+-- module Test.Data.String.Regex (testStringRegex) where
+module Test.Data.String.Regex where
 
-import Data.String.Regex
+-- import Data.String.Regex
 
-import Data.Array.NonEmpty (NonEmptyArray, fromArray)
-import Data.Either (isLeft)
-import Data.Maybe (Maybe(..), fromJust)
-import Data.String.Regex.Flags (dotAll, global, ignoreCase, noFlags)
-import Data.String.Regex.Unsafe (unsafeRegex)
-import Effect (Effect)
-import Effect.Console (log)
-import Partial.Unsafe (unsafePartial)
-import Prelude (type (~>), Unit, discard, not, show, ($), (<<<), (<>), (==))
-import Test.Assert (assert)
+-- import Data.Array.NonEmpty (NonEmptyArray, fromArray)
+-- import Data.Either (isLeft)
+-- import Data.Maybe (Maybe(..), fromJust)
+-- import Data.String.Regex.Flags (dotAll, global, ignoreCase, noFlags)
+-- import Data.String.Regex.Unsafe (unsafeRegex)
+-- import Effect (Effect)
+-- import Effect.Console (log)
+-- import Partial.Unsafe (unsafePartial)
+-- import Prelude (type (~>), Unit, discard, not, show, ($), (<<<), (<>), (==))
+-- import Test.Assert (assert)
 
-testStringRegex :: Effect Unit
-testStringRegex = do
-  log "regex"
-  assert $ test (unsafeRegex "^a" noFlags) "abc"
-  assert $ not (test (unsafeRegex "^b" noFlags) "abc")
-  assert $ isLeft (regex "+" noFlags)
+-- testStringRegex :: Effect Unit
+-- testStringRegex = do
+--   log "regex"
+--   assert $ test (unsafeRegex "^a" noFlags) "abc"
+--   assert $ not (test (unsafeRegex "^b" noFlags) "abc")
+--   assert $ isLeft (regex "+" noFlags)
 
-  log "flags"
-  assert $ "quxbarfoobaz" == replace (unsafeRegex "foo" noFlags) "qux" "foobarfoobaz"
-  assert $ "quxbarquxbaz" == replace (unsafeRegex "foo" global) "qux" "foobarfoobaz"
-  assert $ "quxbarquxbaz" == replace (unsafeRegex "foo" (global <> ignoreCase)) "qux" "foobarFOObaz"
-  assert $ "quxbarfoobaz" == replace (unsafeRegex ".foo" dotAll) "qux" "\nfoobarfoobaz"
+--   log "flags"
+--   assert $ "quxbarfoobaz" == replace (unsafeRegex "foo" noFlags) "qux" "foobarfoobaz"
+--   assert $ "quxbarquxbaz" == replace (unsafeRegex "foo" global) "qux" "foobarfoobaz"
+--   assert $ "quxbarquxbaz" == replace (unsafeRegex "foo" (global <> ignoreCase)) "qux" "foobarFOObaz"
+--   assert $ "quxbarfoobaz" == replace (unsafeRegex ".foo" dotAll) "qux" "\nfoobarfoobaz"
 
-  log "match"
-  assert $ match (unsafeRegex "^abc$" noFlags) "abc" == Just (nea [Just "abc"])
-  assert $ match (unsafeRegex "^abc$" noFlags) "xyz" == Nothing
+--   log "match"
+--   assert $ match (unsafeRegex "^abc$" noFlags) "abc" == Just (nea [Just "abc"])
+--   assert $ match (unsafeRegex "^abc$" noFlags) "xyz" == Nothing
 
-  log "replace"
-  assert $ replace (unsafeRegex "-" noFlags) "!" "a-b-c" == "a!b-c"
+--   log "replace"
+--   assert $ replace (unsafeRegex "-" noFlags) "!" "a-b-c" == "a!b-c"
 
-  log "replace'"
-  assert $ replace' (unsafeRegex "-" noFlags) (\s xs -> "!") "a-b-c" == "a!b-c"
-  assert $ replace' (unsafeRegex "(foo)(bar)?" noFlags) (\s xs -> show xs) "<>" == "<>"
-  assert $ replace' (unsafeRegex "(foo)(bar)?" noFlags) (\s xs -> show xs) "<foo>" == "<[(Just \"foo\"),Nothing]>"
-  assert $ replace' (unsafeRegex "(foo)(bar)?" noFlags) (\s xs -> show xs) "<foobar>" == "<[(Just \"foo\"),(Just \"bar\")]>"
-  assert $ replace' (unsafeRegex "@(?<username>\\w+)" noFlags) (\s xs -> show xs) "@purescript" == "[(Just \"purescript\")]"
+--   log "replace'"
+--   assert $ replace' (unsafeRegex "-" noFlags) (\s xs -> "!") "a-b-c" == "a!b-c"
+--   assert $ replace' (unsafeRegex "(foo)(bar)?" noFlags) (\s xs -> show xs) "<>" == "<>"
+--   assert $ replace' (unsafeRegex "(foo)(bar)?" noFlags) (\s xs -> show xs) "<foo>" == "<[(Just \"foo\"),Nothing]>"
+--   assert $ replace' (unsafeRegex "(foo)(bar)?" noFlags) (\s xs -> show xs) "<foobar>" == "<[(Just \"foo\"),(Just \"bar\")]>"
+--   assert $ replace' (unsafeRegex "@(?<username>\\w+)" noFlags) (\s xs -> show xs) "@purescript" == "[(Just \"purescript\")]"
 
-  log "search"
-  assert $ search (unsafeRegex "b" noFlags) "abc" == Just 1
-  assert $ search (unsafeRegex "d" noFlags) "abc" == Nothing
+--   log "search"
+--   assert $ search (unsafeRegex "b" noFlags) "abc" == Just 1
+--   assert $ search (unsafeRegex "d" noFlags) "abc" == Nothing
 
-  log "split"
-  assert $ split (unsafeRegex "" noFlags) "" == []
-  assert $ split (unsafeRegex "" noFlags) "abc" == ["a", "b", "c"]
-  assert $ split (unsafeRegex "b" noFlags) "" == [""]
-  assert $ split (unsafeRegex "b" noFlags) "abc" == ["a", "c"]
+--   log "split"
+--   assert $ split (unsafeRegex "" noFlags) "" == []
+--   assert $ split (unsafeRegex "" noFlags) "abc" == ["a", "b", "c"]
+--   assert $ split (unsafeRegex "b" noFlags) "" == [""]
+--   assert $ split (unsafeRegex "b" noFlags) "abc" == ["a", "c"]
 
-  log "test"
-  -- Ensure that we have referential transparency for calls to 'test'. No
-  -- global state should be maintained between these two calls:
-  let pattern = unsafeRegex "a" (parseFlags "g")
-  assert $ test pattern "a"
-  assert $ test pattern "a"
+--   log "test"
+--   -- Ensure that we have referential transparency for calls to 'test'. No
+--   -- global state should be maintained between these two calls:
+--   let pattern = unsafeRegex "a" (parseFlags "g")
+--   assert $ test pattern "a"
+--   assert $ test pattern "a"
 
-nea :: Array ~> NonEmptyArray
-nea = unsafePartial fromJust <<< fromArray
+-- nea :: Array ~> NonEmptyArray
+-- nea = unsafePartial fromJust <<< fromArray

--- a/test/Test/Main.purs
+++ b/test/Test/Main.purs
@@ -5,29 +5,29 @@ import Prelude
 import Effect (Effect)
 import Effect.Console (log)
 import Test.Data.String (testString)
-import Test.Data.String.CaseInsensitive (testCaseInsensitiveString)
-import Test.Data.String.CodePoints (testStringCodePoints)
-import Test.Data.String.CodeUnits (testStringCodeUnits)
-import Test.Data.String.NonEmpty (testNonEmptyString)
-import Test.Data.String.NonEmpty.CodeUnits (testNonEmptyStringCodeUnits)
-import Test.Data.String.Regex (testStringRegex)
+-- import Test.Data.String.CaseInsensitive (testCaseInsensitiveString)
+-- import Test.Data.String.CodePoints (testStringCodePoints)
+-- import Test.Data.String.CodeUnits (testStringCodeUnits)
+-- import Test.Data.String.NonEmpty (testNonEmptyString)
+-- import Test.Data.String.NonEmpty.CodeUnits (testNonEmptyStringCodeUnits)
+-- import Test.Data.String.Regex (testStringRegex)
 import Test.Data.String.Unsafe (testStringUnsafe)
 
 main :: Effect Unit
 main = do
   log "\n--- Data.String ---\n"
   testString
-  log "\n--- Data.String.CodePoints ---\n"
-  testStringCodePoints
-  log "\n--- Data.String.CodeUnits ---\n"
-  testStringCodeUnits
+  -- log "\n--- Data.String.CodePoints ---\n"
+  -- testStringCodePoints
+  -- log "\n--- Data.String.CodeUnits ---\n"
+  -- testStringCodeUnits
   log "\n--- Data.String.Unsafe ---\n"
   testStringUnsafe
-  log "\n--- Data.String.Regex ---\n"
-  testStringRegex
-  log "\n--- Data.String.CaseInsensitive ---\n"
-  testCaseInsensitiveString
-  log "\n--- Data.String.NonEmpty ---\n"
-  testNonEmptyString
-  log "\n--- Data.String.NonEmpty.CodeUnits ---\n"
-  testNonEmptyStringCodeUnits
+  -- log "\n--- Data.String.Regex ---\n"
+  -- testStringRegex
+  -- log "\n--- Data.String.CaseInsensitive ---\n"
+  -- testCaseInsensitiveString
+  -- log "\n--- Data.String.NonEmpty ---\n"
+  -- testNonEmptyString
+  -- log "\n--- Data.String.NonEmpty.CodeUnits ---\n"
+  -- testNonEmptyStringCodeUnits

--- a/test/Test/Main.purs
+++ b/test/Test/Main.purs
@@ -7,7 +7,7 @@ import Effect.Console (log)
 import Test.Data.String (testString)
 -- import Test.Data.String.CaseInsensitive (testCaseInsensitiveString)
 -- import Test.Data.String.CodePoints (testStringCodePoints)
--- import Test.Data.String.CodeUnits (testStringCodeUnits)
+import Test.Data.String.CodeUnits (testStringCodeUnits)
 -- import Test.Data.String.NonEmpty (testNonEmptyString)
 -- import Test.Data.String.NonEmpty.CodeUnits (testNonEmptyStringCodeUnits)
 -- import Test.Data.String.Regex (testStringRegex)
@@ -19,8 +19,8 @@ main = do
   testString
   -- log "\n--- Data.String.CodePoints ---\n"
   -- testStringCodePoints
-  -- log "\n--- Data.String.CodeUnits ---\n"
-  -- testStringCodeUnits
+  log "\n--- Data.String.CodeUnits ---\n"
+  testStringCodeUnits
   log "\n--- Data.String.Unsafe ---\n"
   testStringUnsafe
   -- log "\n--- Data.String.Regex ---\n"


### PR DESCRIPTION
These come together because they are needed to be able to reproduce a minimal tests' subset run. Imports imply/depend on merging of the IrRegex PR, as well as SRFI N152 PR for `purescm/purescm`.